### PR TITLE
Update submodule to latest from master, update snapshot version

### DIFF
--- a/MapboxGLAndroidSDK/gradle.properties
+++ b/MapboxGLAndroidSDK/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=8.5.0-SNAPSHOT
+VERSION_NAME=8.6.0-SNAPSHOT
 
 # Only build native dependencies for the current ABI
 # See https://code.google.com/p/android/issues/detail?id=221098#c20


### PR DESCRIPTION
Branch cut happened for `release-sangria`. This PR updates the gl-native submodule to latest on master and updates the snapshot version to match `release-tequila`.