### PR TITLE
Disable local font generation with accessibility high contrast mode

### DIFF
--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -34,6 +34,7 @@ import com.mapbox.mapboxsdk.maps.renderer.textureview.TextureViewMapRenderer;
 import com.mapbox.mapboxsdk.maps.widgets.CompassView;
 import com.mapbox.mapboxsdk.net.ConnectivityReceiver;
 import com.mapbox.mapboxsdk.storage.FileSource;
+import com.mapbox.mapboxsdk.utils.AccessibilityUtils;
 import com.mapbox.mapboxsdk.utils.BitmapUtils;
 
 import java.util.ArrayList;
@@ -282,7 +283,11 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   }
 
   private void initialiseDrawingSurface(MapboxMapOptions options) {
-    String localFontFamily = options.getLocalIdeographFontFamily();
+    String localFontFamily = null;
+    if (!AccessibilityUtils.isHighContrastEnabled(getContext())) {
+      localFontFamily = options.getLocalIdeographFontFamily();
+    }
+
     if (options.getTextureMode()) {
       TextureView textureView = new TextureView(getContext());
       boolean translucentSurface = options.getTranslucentTextureSurface();

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/AccessibilityUtils.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/AccessibilityUtils.java
@@ -1,0 +1,31 @@
+package com.mapbox.mapboxsdk.utils;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.view.accessibility.AccessibilityManager;
+
+import com.mapbox.mapboxsdk.log.Logger;
+
+import java.lang.reflect.Method;
+
+public class AccessibilityUtils {
+
+  private static final String TAG = "Mbgl-AccessibilityUtils";
+  private static final String METHOD_HIGH_TEXT_CONTRAST_ENABLED = "isHighTextContrastEnabled";
+  private static final String ERROR_HIGH_CONTRAST_LOOKUP = "Could not detect high text contrast accessibility setting";
+
+  @SuppressWarnings("JavaReflectionMemberAccess")
+  public static boolean isHighContrastEnabled(@NonNull Context context) {
+    AccessibilityManager accessibility = (AccessibilityManager) context.getSystemService(Context.ACCESSIBILITY_SERVICE);
+    try {
+      Method m = accessibility.getClass().getMethod(METHOD_HIGH_TEXT_CONTRAST_ENABLED);
+      Object result = m.invoke(accessibility);
+      if (result instanceof Boolean) {
+        return (Boolean) result;
+      }
+    } catch (Exception exception) {
+      Logger.i(TAG, ERROR_HIGH_CONTRAST_LOOKUP , exception);
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
Refs #31, mitigates the issue from #32 by disabling local glyph generation when this accessibility feature is active. In this setup, it will download the glyphs online instead of generating them corrupt on device. 