### PR TITLE
Adding automated API javadoc generation scripting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,6 +172,15 @@ commands:
               gcloud auth activate-service-account --key-file secret.json --project mapbox-gl-native-android
               rm secret.json
             fi
+  generate-api-javadoc:
+    steps:
+      - run:
+          name: Generate Maps SDK API javadoc and transfer to `/android-docs`
+          command: |
+            export VERSION_TAG=${CIRCLE_TAG}
+            export GITHUB_TOKEN=${DANGER_GITHUB_API_TOKEN}
+            export DOCS_REPO="android-docs"
+            bash scripts/trigger-maps-documentation-deploy-steps.sh        
 
 jobs:
   # ------------------------------------------------------------------------------
@@ -346,7 +355,7 @@ jobs:
                 make run-android-upload-to-artifactory
               fi
             fi
-
+      - generate-api-javadoc
   # ------------------------------------------------------------------------------
   android-debug-arm-v7-buck:
     docker:

--- a/scripts/trigger-maps-documentation-deploy-steps.sh
+++ b/scripts/trigger-maps-documentation-deploy-steps.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+function step { >&2 echo -e "\033[1m\033[36m* $@\033[0m"; }
+function finish { >&2 echo -en "\033[0m"; }
+trap finish EXIT
+
+SDK_FLAVOR=${SDK_FLAVOR:-"maps"}
+
+step "Triggering automated site and documentation generation for ${SDK_FLAVOR} SDK ${VERSION_TAG}"
+
+# No branch specified, so default branch will be used
+request_body="{
+  \"request\": {
+    \"message\": \"[${SDK_FLAVOR}] ${VERSION_TAG} automated site and documentation generation\",
+    \"config\": {
+      \"merge_mode\": \"deep_merge\",
+      \"env\": {
+        \"SDK_FLAVOR\": \"${SDK_FLAVOR}\",
+        \"RELEASE_TAG\": \"${VERSION_TAG}\"
+      }
+    }
+  }
+}"
+
+step "Making request…"
+
+# Request URL set to docs-sandbox while testing
+curl -s -X POST \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -H "Travis-API-Version: 3" \
+  -H "Authorization: token ${TRAVISCI_API_TOKEN}" \
+  -d "${request_body}" \
+  https://api.travis-ci.com/repo/mapbox%2F${DOCS_REPO}/requests


### PR DESCRIPTION
This pr adds @danswick 's past work to this repo in order to automatically generate API javadocs for https://github.com/mapbox/android-docs. I believe that follow up work will be needed in `/android-docs`.

This pr is:
- a follow up to @danswick 's work at:
  - https://github.com/mapbox/mapbox-gl-native/pull/15299/files
- is related to https://github.com/mapbox/android-docs/pull/1117/files and https://github.com/mapbox/android-docs/pull/1072. 

When a new stable release tag `android-v.X.X.X` is made in this repo, it will kick off the javadoc generation process and open a new pr in https://github.com/mapbox/android-docs

I've added `TRAVISCI_API_TOKEN` to this repo's CircleCI environmental variable list