### PR TITLE
Add check for darwin systems to support local development on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,19 @@ endif
 
 buildtype := $(shell echo "$(BUILDTYPE)" | tr "[A-Z]" "[a-z]")
 
-HOST_PLATFORM = linux
-HOST_PLATFORM_VERSION = $(shell uname -m)
-export NINJA = platform/linux/ninja
-export JOBS ?= $(shell grep --count processor /proc/cpuinfo)
+ifeq ($(shell uname -s), Darwin)
+  HOST_PLATFORM = macos
+  HOST_PLATFORM_VERSION = $(shell uname -m)
+  export NINJA = platform/macos/ninja
+  export JOBS ?= $(shell sysctl -n hw.ncpu)
+else ifeq ($(shell uname -s), Linux)
+  HOST_PLATFORM = linux
+  HOST_PLATFORM_VERSION = $(shell uname -m)
+  export NINJA = platform/linux/ninja
+  export JOBS ?= $(shell grep --count processor /proc/cpuinfo)
+else
+  $(error Cannot determine host platform)
+endif
 
 #### Android targets ###########################################################
 


### PR DESCRIPTION
While making some [updates to the docs site](https://github.com/mapbox/android-docs/pull/1143), I noticed that `make android-javadoc` was failing because of a missing `JOBS` parameter. Comparing this project's `Makefile` to the [original in the mapbox-gl-native](https://github.com/mapbox/mapbox-gl-native/blob/master/Makefile#L18-L28) monorepo, I noticed some missing `HOST_PLATFORM` logic, which was causing the docs build to fail (along with the `make aproj` command in this repo's main readme) on MacOS. 

This PR adds the `HOST_PLATFORM` logic back in, though I am not super familiar with the Makefile world and am not sure if there are any unintended consequences.

cc @langsmith @tarigo 