### PR TITLE
Invoke cancelable callback when zoom/tilt while tracking is ignored

### DIFF
--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
@@ -739,14 +739,15 @@ public final class LocationComponent {
                                 @Nullable MapboxMap.CancelableCallback callback) {
     checkActivationState();
     if (!isLayerReady) {
+      notifyUnsuccessfulCameraOperation(callback, null);
       return;
     } else if (getCameraMode() == CameraMode.NONE) {
-      Logger.e(TAG, String.format("%s%s",
+      notifyUnsuccessfulCameraOperation(callback, String.format("%s%s",
         "LocationComponent#zoomWhileTracking method can only be used",
         " when a camera mode other than CameraMode#NONE is engaged."));
       return;
     } else if (locationCameraController.isTransitioning()) {
-      Logger.e(TAG,
+      notifyUnsuccessfulCameraOperation(callback,
         "LocationComponent#zoomWhileTracking method call is ignored because the camera mode is transitioning");
       return;
     }
@@ -817,14 +818,15 @@ public final class LocationComponent {
                                 @Nullable MapboxMap.CancelableCallback callback) {
     checkActivationState();
     if (!isLayerReady) {
+      notifyUnsuccessfulCameraOperation(callback, null);
       return;
     } else if (getCameraMode() == CameraMode.NONE) {
-      Logger.e(TAG, String.format("%s%s",
+      notifyUnsuccessfulCameraOperation(callback, String.format("%s%s",
         "LocationComponent#tiltWhileTracking method can only be used",
         " when a camera mode other than CameraMode#NONE is engaged."));
       return;
     } else if (locationCameraController.isTransitioning()) {
-      Logger.e(TAG,
+      notifyUnsuccessfulCameraOperation(callback,
         "LocationComponent#tiltWhileTracking method call is ignored because the camera mode is transitioning");
       return;
     }
@@ -1604,6 +1606,17 @@ public final class LocationComponent {
   private void checkActivationState() {
     if (!isComponentInitialized) {
       throw new LocationComponentNotInitializedException();
+    }
+  }
+
+  private void notifyUnsuccessfulCameraOperation(@Nullable MapboxMap.CancelableCallback callback,
+                                                 @Nullable String msg) {
+    if (msg != null) {
+      Logger.e(TAG, msg);
+    }
+
+    if (callback != null) {
+      callback.onCancel();
     }
   }
 

--- a/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
+++ b/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
@@ -467,4 +467,124 @@ class LocationComponentTest {
     verify(locationAnimatorCoordinator).resetAllLayerAnimations()
     verify(renderChangeListener).onRenderModeChanged(RenderMode.NORMAL)
   }
+
+  @Test
+  fun tiltWhileTracking_notReady() {
+    `when`(mapboxMap.cameraPosition).thenReturn(CameraPosition.DEFAULT)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.isLocationComponentEnabled = true
+
+    val callback = mock(MapboxMap.CancelableCallback::class.java)
+
+    locationComponent.tiltWhileTracking(30.0, 500L, callback)
+    verify(callback).onCancel()
+    verify(locationAnimatorCoordinator, times(0)).feedNewTilt(anyDouble(), any(), anyLong(), any())
+  }
+
+  @Test
+  fun tiltWhileTracking_notTracking() {
+    `when`(mapboxMap.cameraPosition).thenReturn(CameraPosition.DEFAULT)
+    `when`(locationCameraController.cameraMode).thenReturn(CameraMode.NONE)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.isLocationComponentEnabled = true
+    locationComponent.onStart()
+
+    val callback = mock(MapboxMap.CancelableCallback::class.java)
+
+    locationComponent.tiltWhileTracking(30.0, 500L, callback)
+    verify(callback).onCancel()
+    verify(locationAnimatorCoordinator, times(0)).feedNewTilt(anyDouble(), any(), anyLong(), any())
+  }
+
+  @Test
+  fun tiltWhileTracking_transitioning() {
+    `when`(mapboxMap.cameraPosition).thenReturn(CameraPosition.DEFAULT)
+    `when`(locationCameraController.cameraMode).thenReturn(CameraMode.TRACKING)
+    `when`(locationCameraController.isTransitioning).thenReturn(true)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.isLocationComponentEnabled = true
+    locationComponent.onStart()
+
+    val callback = mock(MapboxMap.CancelableCallback::class.java)
+
+    locationComponent.tiltWhileTracking(30.0, 500L, callback)
+    verify(callback).onCancel()
+    verify(locationAnimatorCoordinator, times(0)).feedNewTilt(anyDouble(), any(), anyLong(), any())
+  }
+
+  @Test
+  fun tiltWhileTracking_sucessful() {
+    `when`(mapboxMap.cameraPosition).thenReturn(CameraPosition.DEFAULT)
+    `when`(locationCameraController.cameraMode).thenReturn(CameraMode.TRACKING)
+    `when`(locationCameraController.isTransitioning).thenReturn(false)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.isLocationComponentEnabled = true
+    locationComponent.onStart()
+
+    val callback = mock(MapboxMap.CancelableCallback::class.java)
+
+    locationComponent.tiltWhileTracking(30.0, 500L, callback)
+    verify(callback, times(0)).onCancel()
+    verify(locationAnimatorCoordinator).feedNewTilt(30.0, CameraPosition.DEFAULT, 500L, callback)
+  }
+
+  @Test
+  fun zoomWhileTracking_notReady() {
+    `when`(mapboxMap.cameraPosition).thenReturn(CameraPosition.DEFAULT)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.isLocationComponentEnabled = true
+
+    val callback = mock(MapboxMap.CancelableCallback::class.java)
+
+    locationComponent.zoomWhileTracking(14.0, 500L, callback)
+    verify(callback).onCancel()
+    verify(locationAnimatorCoordinator, times(0)).feedNewZoomLevel(anyDouble(), any(), anyLong(), any())
+  }
+
+  @Test
+  fun zoomWhileTracking_notTracking() {
+    `when`(mapboxMap.cameraPosition).thenReturn(CameraPosition.DEFAULT)
+    `when`(locationCameraController.cameraMode).thenReturn(CameraMode.NONE)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.isLocationComponentEnabled = true
+    locationComponent.onStart()
+
+    val callback = mock(MapboxMap.CancelableCallback::class.java)
+
+    locationComponent.zoomWhileTracking(14.0, 500L, callback)
+    verify(callback).onCancel()
+    verify(locationAnimatorCoordinator, times(0)).feedNewZoomLevel(anyDouble(), any(), anyLong(), any())
+  }
+
+  @Test
+  fun zoomWhileTracking_transitioning() {
+    `when`(mapboxMap.cameraPosition).thenReturn(CameraPosition.DEFAULT)
+    `when`(locationCameraController.cameraMode).thenReturn(CameraMode.TRACKING)
+    `when`(locationCameraController.isTransitioning).thenReturn(true)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.isLocationComponentEnabled = true
+    locationComponent.onStart()
+
+    val callback = mock(MapboxMap.CancelableCallback::class.java)
+
+    locationComponent.zoomWhileTracking(14.0, 500L, callback)
+    verify(callback).onCancel()
+    verify(locationAnimatorCoordinator, times(0)).feedNewZoomLevel(anyDouble(), any(), anyLong(), any())
+  }
+
+  @Test
+  fun zoomWhileTracking_successful() {
+    `when`(mapboxMap.cameraPosition).thenReturn(CameraPosition.DEFAULT)
+    `when`(locationCameraController.cameraMode).thenReturn(CameraMode.TRACKING)
+    `when`(locationCameraController.isTransitioning).thenReturn(false)
+    locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)
+    locationComponent.isLocationComponentEnabled = true
+    locationComponent.onStart()
+
+    val callback = mock(MapboxMap.CancelableCallback::class.java)
+
+    locationComponent.zoomWhileTracking(14.0, 500L, callback)
+    verify(callback, times(0)).onCancel()
+    verify(locationAnimatorCoordinator).feedNewZoomLevel(14.0, CameraPosition.DEFAULT, 500L, callback)
+  }
 }


### PR DESCRIPTION
To make the callbacks more reliable, we should ensure to invoke them even when the transition is ignored.