### PR TITLE
Remove core benchmark trigger

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,14 +294,6 @@ jobs:
           name: Android nitpick
           command: make run-android-nitpick
       - run:
-          name: Trigger core benchmark run
-          command: |
-            if [ -n "${MOBILE_METRICS_TOKEN}" ]; then
-              if [[ $CIRCLE_BRANCH == master ]]; then
-                curl -u $MOBILE_METRICS_TOKEN -d build_parameters[CIRCLE_JOB]=android-core-benchmark https://circleci.com/api/v1.1/project/github/mapbox/mobile-metrics/tree/master
-              fi
-            fi
-      - run:
           name: Trigger android benchmark run
           command: |
             if [ -n "${MOBILE_METRICS_TOKEN}" ]; then


### PR DESCRIPTION
With removing platform code upstream in https://github.com/mapbox/mapbox-gl-native/pull/15970, we are breaking a downstream core metric build (more context in https://github.com/mapbox/mapbox-gl-native/issues/15977#issuecomment-560360947). This PR removes the webhook invocation for that given metric build so we don't execute a broken CI job. 

cc @tmpsantos 