### PR TITLE
Expose getter for the view used for rendering OpenGL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 
 ### Features
 - Introduce OfflineManager.runPackDatabaseAutomatically(boolean) and remove the redundant OfflineRegion.deleteAndSkipPackDatabase() method [#78](https://github.com/mapbox/mapbox-gl-native-android/pull/78)
+- Expose getter for the view used for rendering OpenGL content on [#87](https://github.com/mapbox/mapbox-gl-native-android/pull/87)
 
 ### Performance improvements
 - Make network requests for expired resources lower priority than requests for new resources. ([#15950](https://github.com/mapbox/mapbox-gl-native/pull/15950))

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -70,6 +70,8 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   private NativeMap nativeMapView;
   @Nullable
   private MapboxMap mapboxMap;
+  private View renderView;
+
   private AttributionClickListener attributionClickListener;
   private MapboxMapOptions mapboxMapOptions;
   private MapRenderer mapRenderer;
@@ -296,6 +298,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
       };
 
       addView(textureView, 0);
+      renderView = textureView;
     } else {
       MapboxGLSurfaceView glSurfaceView = new MapboxGLSurfaceView(getContext());
       glSurfaceView.setZOrderMediaOverlay(mapboxMapOptions.getRenderSurfaceOnTop());
@@ -308,6 +311,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
       };
 
       addView(glSurfaceView, 0);
+      renderView = glSurfaceView;
     }
 
     boolean crossSourceCollisions = mapboxMapOptions.getCrossSourceCollisions();
@@ -463,6 +467,20 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   @UiThread
   public boolean isDestroyed() {
     return destroyed;
+  }
+
+  /**
+   * Returns the View used for rendering OpenGL.
+   * <p>
+   * The type of the returned view is either a GLSurfaceView or a TextureView.
+   * </p>
+   *
+   * @return the view used for rendering OpenGL
+   */
+  @NonNull
+  @UiThread
+  public View getRenderView() {
+    return renderView;
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/maps/RenderViewGetterTest.kt
+++ b/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/maps/RenderViewGetterTest.kt
@@ -1,0 +1,51 @@
+package com.mapbox.mapboxsdk.testapp.maps
+
+import android.opengl.GLSurfaceView
+import android.support.test.annotation.UiThreadTest
+import android.support.test.rule.ActivityTestRule
+import android.support.test.runner.AndroidJUnit4
+import android.view.TextureView
+import android.view.ViewGroup
+import com.mapbox.mapboxsdk.AppCenter
+import com.mapbox.mapboxsdk.maps.MapView
+import com.mapbox.mapboxsdk.maps.MapboxMapOptions
+import com.mapbox.mapboxsdk.testapp.activity.FeatureOverviewActivity
+import java.util.concurrent.CountDownLatch
+import junit.framework.Assert.assertNotNull
+import junit.framework.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RenderViewGetterTest : AppCenter() {
+
+  @Rule
+  @JvmField
+  var rule = ActivityTestRule(FeatureOverviewActivity::class.java)
+
+  private lateinit var rootView: ViewGroup
+  private lateinit var mapView: MapView
+  private val latch: CountDownLatch = CountDownLatch(1)
+
+  @Test
+  @UiThreadTest
+  fun testGLSurfaceView() {
+    rootView = rule.activity.findViewById(android.R.id.content)
+    mapView = MapView(rule.activity)
+    assertNotNull(mapView.renderView)
+    assertTrue(mapView.renderView is GLSurfaceView)
+  }
+
+  @Test
+  @UiThreadTest
+  fun testTextureView() {
+    rootView = rule.activity.findViewById(android.R.id.content)
+    mapView = MapView(rule.activity,
+      MapboxMapOptions.createFromAttributes(rule.activity, null)
+        .textureMode(true)
+    )
+    assertNotNull(mapView.renderView)
+    assertTrue(mapView.renderView is TextureView)
+  }
+}


### PR DESCRIPTION
This PR is a proposal to close #77, alternatively we could opt to assign id to the render surface, so a user can rely on `mapView.findViewById(R.id.renderSurface)` instead.

@mapbox/maps-android wdyt? 