### PR TITLE
Keep the whole LocalGlyphRasterizer class to prevent constructor minification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Mapbox welcomes participation and contributions from everyone.  If you'd like to do so please see the [`Contributing Guide`](https://github.com/mapbox/mapbox-gl-native/blob/master/CONTRIBUTING.md) first to get started.
 
+## master
+### Bug fixes
+- Fixed a crash caused by an unintentional minification of the `LocalGlyphRasterizer`. [#102](https://github.com/mapbox/mapbox-gl-native-android/pull/102)
+
 ## 8.6.0-beta.1 - December 6, 2019
 [Changes](https://github.com/mapbox/mapbox-gl-native/compare/android-v8.6.0-alpha.2...android-v8.6.0-beta.1) since [Mapbox Maps SDK for Android v8.6.0-alpha.2](https://github.com/mapbox/mapbox-gl-native/releases/tag/android-v8.6.0-alpha.2):
 ### Features
@@ -22,7 +26,7 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 ## 8.6.0-alpha.2 - November 22, 2019
 [Changes](https://github.com/mapbox/mapbox-gl-native/compare/android-v8.6.0-alpha.1...android-v8.6.0-alpha.2) since [Mapbox Maps SDK for Android v8.6.0-alpha.1](https://github.com/mapbox/mapbox-gl-native/releases/tag/android-v8.6.0-alpha.1):
 
-### Bugs
+### Bug fixes
  - Synchronise LibaryLoader#loadLibrary to avoid race conditions resulting in UnsatisfiedLinkError [#58](https://github.com/mapbox/mapbox-gl-native-android/pull/58)
 
 ## 8.5.1 - November 20, 2019

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/text/LocalGlyphRasterizer.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/text/LocalGlyphRasterizer.java
@@ -14,6 +14,7 @@ import android.support.annotation.WorkerThread;
  * LocalGlyphRasterizer is the Android-specific platform implementation used
  * by the portable local_glyph_rasterizer.hpp
  */
+@Keep
 public class LocalGlyphRasterizer {
   private final Bitmap bitmap;
   @NonNull
@@ -49,7 +50,6 @@ public class LocalGlyphRasterizer {
    * @return Return a {@link Bitmap} to be displayed in the requested tile.
    */
   @WorkerThread
-  @Keep
   protected Bitmap drawGlyphBitmap(String fontFamily, boolean bold, char glyphID) {
     paint.setTypeface(Typeface.create(fontFamily, bold ? Typeface.BOLD : Typeface.NORMAL));
     canvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native-android/issues/100. Requires a backport.