### PR TITLE
Deprecate MapboxMap#cycleDebugOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 ## master
 ### Bug fixes
 - Fixed a crash caused by an unintentional minification of the `LocalGlyphRasterizer`. [#102](https://github.com/mapbox/mapbox-gl-native-android/pull/102)
+- Deprecated `MapboxMap#cycleDebugOptions` and fixed an `UnsatisfiedLinkError` when accessed. [#104](https://github.com/mapbox/mapbox-gl-native-android/pull/104)
 
 ## 8.6.0-beta.1 - December 6, 2019
 [Changes](https://github.com/mapbox/mapbox-gl-native/compare/android-v8.6.0-alpha.2...android-v8.6.0-beta.1) since [Mapbox Maps SDK for Android v8.6.0-alpha.2](https://github.com/mapbox/mapbox-gl-native/releases/tag/android-v8.6.0-alpha.2):

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -775,10 +775,12 @@ public final class MapboxMap {
    * any map debug options enabled or disabled.
    *
    * @see #isDebugActive()
+   * @deprecated use {@link #setDebugActive(boolean)}
    */
+  @Deprecated
   public void cycleDebugOptions() {
-    nativeMapView.cycleDebugOptions();
-    this.debugActive = nativeMapView.getDebug();
+    this.debugActive = !nativeMapView.getDebug();
+    nativeMapView.setDebug(debugActive);
   }
 
   //

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMap.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMap.java
@@ -209,8 +209,6 @@ interface NativeMap {
 
   boolean getDebug();
 
-  void cycleDebugOptions();
-
   void setReachability(boolean status);
 
   void setApiBaseUrl(String baseUrl);

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -584,14 +584,6 @@ final class NativeMapView implements NativeMap {
   }
 
   @Override
-  public void cycleDebugOptions() {
-    if (checkState("cycleDebugOptions")) {
-      return;
-    }
-    nativeCycleDebugOptions();
-  }
-
-  @Override
   public boolean getDebug() {
     if (checkState("getDebug")) {
       return false;
@@ -1262,9 +1254,6 @@ final class NativeMapView implements NativeMap {
 
   @Keep
   private native void nativeSetDebug(boolean debug);
-
-  @Keep
-  private native void nativeCycleDebugOptions();
 
   @Keep
   private native boolean nativeGetDebug();

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DebugModeActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DebugModeActivity.java
@@ -164,8 +164,8 @@ public class DebugModeActivity extends AppCompatActivity implements OnMapReadyCa
     FloatingActionButton fabDebug = findViewById(R.id.fabDebug);
     fabDebug.setOnClickListener(view -> {
       if (mapboxMap != null) {
+        mapboxMap.setDebugActive(!mapboxMap.isDebugActive());
         Timber.d("Debug FAB: isDebug Active? %s", mapboxMap.isDebugActive());
-        mapboxMap.cycleDebugOptions();
       }
     });
   }


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native-android/issues/103. Requires a backport.