### PR TITLE
Add getVisibleCoordinateBounds method.

### DIFF
--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/LatLngBounds.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/LatLngBounds.java
@@ -372,9 +372,8 @@ public class LatLngBounds implements Parcelable {
   }
 
   private boolean containsLongitude(final double longitude) {
-    return ((longitude <= this.longitudeEast) && (longitude >= this.longitudeWest))
-            || ((longitude <= this.longitudeEast - 360.0) && (longitude >= this.longitudeWest - 360.0))
-            || ((longitude <= this.longitudeEast + 360.0) && (longitude >= this.longitudeWest + 360.0));
+    return (longitude <= this.longitudeEast)
+            && (longitude >= this.longitudeWest);
   }
 
   /**

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/LatLngBounds.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/LatLngBounds.java
@@ -372,8 +372,9 @@ public class LatLngBounds implements Parcelable {
   }
 
   private boolean containsLongitude(final double longitude) {
-    return (longitude <= this.longitudeEast)
-      && (longitude >= this.longitudeWest);
+    return ((longitude <= this.longitudeEast) && (longitude >= this.longitudeWest))
+            || ((longitude <= this.longitudeEast - 360.0) && (longitude >= this.longitudeWest - 360.0))
+            || ((longitude <= this.longitudeEast + 360.0) && (longitude >= this.longitudeWest + 360.0));
   }
 
   /**

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/VisibleRegion.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/VisibleRegion.java
@@ -54,10 +54,10 @@ public class VisibleRegion implements Parcelable {
   /**
    * Creates a VisibleRegion given the four corners of the camera.
    *
-   * @param farLeft      A LatLng object containing the latitude and longitude of the near left corner of the region.
-   * @param farRight     A LatLng object containing the latitude and longitude of the near left corner of the region.
+   * @param farLeft      A LatLng object containing the latitude and longitude of the far left corner of the region.
+   * @param farRight     A LatLng object containing the latitude and longitude of the far right corner of the region.
    * @param nearLeft     A LatLng object containing the latitude and longitude of the near left corner of the region.
-   * @param nearRight    A LatLng object containing the latitude and longitude of the near left corner of the region.
+   * @param nearRight    A LatLng object containing the latitude and longitude of the near right corner of the region.
    * @param latLngBounds The smallest bounding box that includes the visible region defined in this class.
    */
   public VisibleRegion(LatLng farLeft, LatLng farRight, LatLng nearLeft, LatLng nearRight, LatLngBounds latLngBounds) {

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMap.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMap.java
@@ -195,7 +195,7 @@ interface NativeMap {
 
   void pixelsForLatLngs(@NonNull double[] input, @NonNull double[] output);
 
-  void getVisibleCoordinateBounds(int width, int height, @NonNull double[] output);
+  void getVisibleCoordinateBounds(@NonNull double[] output);
 
   LatLng latLngForPixel(@NonNull PointF pixel);
 

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMap.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMap.java
@@ -195,6 +195,8 @@ interface NativeMap {
 
   void pixelsForLatLngs(@NonNull double[] input, @NonNull double[] output);
 
+  void getVisibleCoordinateBounds(int width, int height, @NonNull double[] output);
+
   LatLng latLngForPixel(@NonNull PointF pixel);
 
   void latLngsForPixels(@NonNull double[] input, @NonNull double[] output);

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -651,9 +651,9 @@ final class NativeMapView implements NativeMap {
   }
 
   @Override
-  public void getVisibleCoordinateBounds(int width, int height, @NonNull double[] output) {
+  public void getVisibleCoordinateBounds(@NonNull double[] output) {
     if (!checkState("getVisibleCoordinateBounds")) {
-      nativeGetVisibleCoordinateBounds(width, height, output, pixelRatio);
+      nativeGetVisibleCoordinateBounds(output);
     }
   }
 
@@ -1290,7 +1290,7 @@ final class NativeMapView implements NativeMap {
   private native void nativePixelsForLatLngs(double[] input, double[] output, float pixelRatio);
 
   @Keep
-  private native void nativeGetVisibleCoordinateBounds(int width, int height, double[] output, float pixelRatio);
+  private native void nativeGetVisibleCoordinateBounds(double[] output);
 
   @NonNull
   @Keep

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -651,6 +651,13 @@ final class NativeMapView implements NativeMap {
   }
 
   @Override
+  public void getVisibleCoordinateBounds(int width, int height, @NonNull double[] output) {
+    if (!checkState("getVisibleCoordinateBounds")) {
+      nativeGetVisibleCoordinateBounds(width, height, output, pixelRatio);
+    }
+  }
+
+  @Override
   public LatLng latLngForPixel(@NonNull PointF pixel) {
     if (checkState("latLngForPixel")) {
       return new LatLng();
@@ -1281,6 +1288,9 @@ final class NativeMapView implements NativeMap {
 
   @Keep
   private native void nativePixelsForLatLngs(double[] input, double[] output, float pixelRatio);
+
+  @Keep
+  private native void nativeGetVisibleCoordinateBounds(int width, int height, double[] output, float pixelRatio);
 
   @NonNull
   @Keep

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Projection.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Projection.java
@@ -213,7 +213,7 @@ public class Projection {
    *               lonEast, latSouth, lonWest).
    */
   public void getVisibleCoordinateBounds(@NonNull double[] bounds) {
-    nativeMapView.getVisibleCoordinateBounds(mapView.getWidth(), mapView.getHeight(), bounds);
+    nativeMapView.getVisibleCoordinateBounds(bounds);
   }
 
   /**

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Projection.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Projection.java
@@ -204,6 +204,19 @@ public class Projection {
   }
 
   /**
+   * Gets a projection of the viewing frustum for converting between screen coordinates and
+   * geo-latitude/longitude coordinate bounds.
+   * <p>
+   * This method ignores the content padding.
+   *
+   * @param bounds an array of 4 output values representing bounds(in the order of latNorth,
+   *               lonEast, latSouth, lonWest).
+   */
+  public void getVisibleCoordinateBounds(@NonNull double[] bounds) {
+    nativeMapView.getVisibleCoordinateBounds(mapView.getWidth(), mapView.getHeight(), bounds);
+  }
+
+  /**
    * Takes two {@link Point}s and finds the geographic bearing between them.
    *
    * @param latLng1 the first point used for calculating the bearing

--- a/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/VisibleRegionTest.kt
+++ b/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/VisibleRegionTest.kt
@@ -204,6 +204,30 @@ class VisibleRegionTest : BaseTest() {
   }
 
   @Test
+  fun visibleRegionOverDatelineBigSizeRegionTest() {
+    validateTestSetup()
+    invoke(mapboxMap) { _: UiController, mapboxMap: MapboxMap ->
+      mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(LatLng(0.0, 180.0), 0.0))
+      val latLngs = listOf(
+        mapboxMap.getLatLngFromScreenCoords(0f, 0f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, 0f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width.toFloat(), 0f)
+          .also { it.longitude += 360 },
+        mapboxMap.getLatLngFromScreenCoords(mapView.width.toFloat(), mapView.height / 2f)
+          .also { it.longitude += 360 },
+        mapboxMap.getLatLngFromScreenCoords(mapView.width.toFloat(), mapView.height.toFloat())
+          .also { it.longitude += 360 },
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height.toFloat()),
+        mapboxMap.getLatLngFromScreenCoords(0f, mapView.height.toFloat()),
+        mapboxMap.getLatLngFromScreenCoords(0f, mapView.height / 2f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f)
+      )
+      val visibleRegion = mapboxMap.projection.visibleRegion
+      assertTrue(latLngs.all { visibleRegion.latLngBounds.contains(it) })
+    }
+  }
+
+  @Test
   fun paddedVisibleRegionOverDatelineTest() {
     validateTestSetup()
     invoke(mapboxMap) { _: UiController, mapboxMap: MapboxMap ->
@@ -421,7 +445,7 @@ class VisibleRegionTest : BaseTest() {
   }
 
   @Test
-  fun visibleRegionBoundsOverDatelineEqualTest() {
+  fun visibleRegionBoundsOverDatelineTest() {
     validateTestSetup()
     invoke(mapboxMap) { _: UiController, mapboxMap: MapboxMap ->
       mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(LatLng(0.0, 180.0), 8.0))
@@ -442,9 +466,49 @@ class VisibleRegionTest : BaseTest() {
       val bounds = doubleArrayOf(0.0, 0.0, 0.0, 0.0)
       mapboxMap.projection.getVisibleCoordinateBounds(bounds)
       val latLngBounds = LatLngBounds.from(bounds[0], bounds[1], bounds[2], bounds[3])
+      assertTrue(latLngs.all { latLngBounds.contains(it) })
+    }
+  }
+
+  @Test
+  fun visibleRegionBoundsOverDatelineBigSizeRegionTest() {
+    validateTestSetup()
+    invoke(mapboxMap) { _: UiController, mapboxMap: MapboxMap ->
+      mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(LatLng(0.0, -180.0), 0.0))
+      val latLngs = listOf(
+        mapboxMap.getLatLngFromScreenCoords(0f, 0f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, 0f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width.toFloat(), 0f)
+          .also { it.longitude += 360 },
+        mapboxMap.getLatLngFromScreenCoords(mapView.width.toFloat(), mapView.height / 2f)
+          .also { it.longitude += 360 },
+        mapboxMap.getLatLngFromScreenCoords(mapView.width.toFloat(), mapView.height.toFloat())
+          .also { it.longitude += 360 },
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height.toFloat()),
+        mapboxMap.getLatLngFromScreenCoords(0f, mapView.height.toFloat()),
+        mapboxMap.getLatLngFromScreenCoords(0f, mapView.height / 2f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f)
+      )
+      val bounds = doubleArrayOf(0.0, 0.0, 0.0, 0.0)
+      mapboxMap.projection.getVisibleCoordinateBounds(bounds)
+      val latLngBounds = LatLngBounds.from(bounds[0], bounds[1], bounds[2], bounds[3])
+      assertTrue(latLngs.all { latLngBounds.contains(it) })
+    }
+  }
+
+  @Test
+  fun visibleRegionBoundsOverDatelineLatitudeZeroTest() {
+    validateTestSetup()
+    invoke(mapboxMap) { _: UiController, mapboxMap: MapboxMap ->
+      mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(LatLng(0.0, 180.0), 8.0))
+      val shift = mapboxMap.getLatLngFromScreenCoords(0f, 0f)
+      mapboxMap.moveCamera(CameraUpdateFactory.newLatLng(LatLng(0.0, 180.0 - shift.longitude)))
+
+      val bounds = doubleArrayOf(0.0, 0.0, 0.0, 0.0)
+      mapboxMap.projection.getVisibleCoordinateBounds(bounds)
+      val latLngBounds = LatLngBounds.from(bounds[0], bounds[1], bounds[2], bounds[3])
       val visibleRegion = mapboxMap.projection.visibleRegion
       assertTrue(latLngBounds == visibleRegion.latLngBounds)
-      assertTrue(latLngs.all { latLngBounds.contains(it) })
     }
   }
 
@@ -475,7 +539,7 @@ class VisibleRegionTest : BaseTest() {
   }
 
   @Test
-  fun visibleRotatedRegionBoundOverDatelineEqualTest() {
+  fun visibleRotatedRegionBoundsOverDatelineTest() {
     validateTestSetup()
     invoke(mapboxMap) { _: UiController, mapboxMap: MapboxMap ->
       mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(LatLng(0.0, 180.0), 8.0))
@@ -494,8 +558,6 @@ class VisibleRegionTest : BaseTest() {
         val bounds = doubleArrayOf(0.0, 0.0, 0.0, 0.0)
         mapboxMap.projection.getVisibleCoordinateBounds(bounds)
         val latLngBounds = LatLngBounds.from(bounds[0], bounds[1], bounds[2], bounds[3])
-        val visibleRegion = mapboxMap.projection.visibleRegion
-        assertTrue(latLngBounds == visibleRegion.latLngBounds)
         assertTrue(latLngs.all { latLngBounds.contains(it) })
       }
     }

--- a/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/VisibleRegionTest.kt
+++ b/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/VisibleRegionTest.kt
@@ -4,6 +4,7 @@ import android.graphics.PointF
 import androidx.test.espresso.UiController
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory
 import com.mapbox.mapboxsdk.geometry.LatLng
+import com.mapbox.mapboxsdk.geometry.LatLngBounds
 import com.mapbox.mapboxsdk.testapp.action.MapboxMapAction.invoke
 import com.mapbox.mapboxsdk.testapp.activity.BaseTest
 import com.mapbox.mapboxsdk.testapp.activity.espresso.PixelTestActivity
@@ -390,6 +391,112 @@ class VisibleRegionTest : BaseTest() {
         mapboxMap.moveCamera(CameraUpdateFactory.bearingTo(bearing.toDouble()))
         val visibleRegion = mapboxMap.projection.visibleRegion
         assertTrue(latLngs.all { visibleRegion.latLngBounds.contains(it) })
+      }
+    }
+  }
+
+  @Test
+  fun visibleRegionWithBoundsEqualTest() {
+    validateTestSetup()
+    invoke(mapboxMap) { _: UiController, mapboxMap: MapboxMap ->
+      mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(LatLng(0.0, 0.0), 8.0))
+      val latLngs = listOf(
+        mapboxMap.getLatLngFromScreenCoords(0f, 0f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, 0f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width.toFloat(), 0f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width.toFloat(), mapView.height / 2f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width.toFloat(), mapView.height.toFloat()),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height.toFloat()),
+        mapboxMap.getLatLngFromScreenCoords(0f, mapView.height.toFloat()),
+        mapboxMap.getLatLngFromScreenCoords(0f, mapView.height / 2f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f)
+      )
+      val bounds = doubleArrayOf(0.0, 0.0, 0.0, 0.0)
+      mapboxMap.projection.getVisibleCoordinateBounds(bounds)
+      val latLngBounds = LatLngBounds.from(bounds[0], bounds[1], bounds[2], bounds[3])
+      val visibleRegion = mapboxMap.projection.visibleRegion
+      assertTrue(latLngBounds == visibleRegion.latLngBounds)
+      assertTrue(latLngs.all { latLngBounds.contains(it) })
+    }
+  }
+
+  @Test
+  fun visibleRegionBoundsOverDatelineEqualTest() {
+    validateTestSetup()
+    invoke(mapboxMap) { _: UiController, mapboxMap: MapboxMap ->
+      mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(LatLng(0.0, 180.0), 8.0))
+      val latLngs = listOf(
+        mapboxMap.getLatLngFromScreenCoords(0f, 0f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, 0f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width.toFloat(), 0f)
+          .also { it.longitude += 360 },
+        mapboxMap.getLatLngFromScreenCoords(mapView.width.toFloat(), mapView.height / 2f)
+          .also { it.longitude += 360 },
+        mapboxMap.getLatLngFromScreenCoords(mapView.width.toFloat(), mapView.height.toFloat())
+          .also { it.longitude += 360 },
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height.toFloat()),
+        mapboxMap.getLatLngFromScreenCoords(0f, mapView.height.toFloat()),
+        mapboxMap.getLatLngFromScreenCoords(0f, mapView.height / 2f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f)
+      )
+      val bounds = doubleArrayOf(0.0, 0.0, 0.0, 0.0)
+      mapboxMap.projection.getVisibleCoordinateBounds(bounds)
+      val latLngBounds = LatLngBounds.from(bounds[0], bounds[1], bounds[2], bounds[3])
+      val visibleRegion = mapboxMap.projection.visibleRegion
+      assertTrue(latLngBounds == visibleRegion.latLngBounds)
+      assertTrue(latLngs.all { latLngBounds.contains(it) })
+    }
+  }
+
+  @Test
+  fun visibleRotatedRegionBoundEqualTest() {
+    validateTestSetup()
+    invoke(mapboxMap) { _: UiController, mapboxMap: MapboxMap ->
+      mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(LatLng(0.0, 0.0), 8.0))
+      val d = Math.min(mapboxMap.width, mapboxMap.height) / 4
+      val latLngs = listOf(
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f - d / 2f, mapView.height / 2f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f + d / 2f, mapView.height / 2f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f - d / 2f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f + d / 2f)
+      )
+
+      for (bearing in 45 until 360 step 45) {
+        mapboxMap.moveCamera(CameraUpdateFactory.bearingTo(bearing.toDouble()))
+        val bounds = doubleArrayOf(0.0, 0.0, 0.0, 0.0)
+        mapboxMap.projection.getVisibleCoordinateBounds(bounds)
+        val latLngBounds = LatLngBounds.from(bounds[0], bounds[1], bounds[2], bounds[3])
+        val visibleRegion = mapboxMap.projection.visibleRegion
+        assertTrue(latLngBounds == visibleRegion.latLngBounds)
+        assertTrue(latLngs.all { latLngBounds.contains(it) })
+      }
+    }
+  }
+
+  @Test
+  fun visibleRotatedRegionBoundOverDatelineEqualTest() {
+    validateTestSetup()
+    invoke(mapboxMap) { _: UiController, mapboxMap: MapboxMap ->
+      mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(LatLng(0.0, 180.0), 8.0))
+      val d = Math.min(mapboxMap.width, mapboxMap.height) / 4
+      val latLngs = listOf(
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f - d / 2f, mapView.height / 2f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f + d / 2f, mapView.height / 2f)
+          .also { it.longitude += 360 },
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f - d / 2f),
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f + d / 2f)
+      )
+
+      for (bearing in 45 until 360 step 45) {
+        mapboxMap.moveCamera(CameraUpdateFactory.bearingTo(bearing.toDouble()))
+        val bounds = doubleArrayOf(0.0, 0.0, 0.0, 0.0)
+        mapboxMap.projection.getVisibleCoordinateBounds(bounds)
+        val latLngBounds = LatLngBounds.from(bounds[0], bounds[1], bounds[2], bounds[3])
+        val visibleRegion = mapboxMap.projection.visibleRegion
+        assertTrue(latLngBounds == visibleRegion.latLngBounds)
+        assertTrue(latLngs.all { latLngBounds.contains(it) })
       }
     }
   }

--- a/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/VisibleRegionTest.kt
+++ b/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/VisibleRegionTest.kt
@@ -204,30 +204,6 @@ class VisibleRegionTest : BaseTest() {
   }
 
   @Test
-  fun visibleRegionOverDatelineBigSizeRegionTest() {
-    validateTestSetup()
-    invoke(mapboxMap) { _: UiController, mapboxMap: MapboxMap ->
-      mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(LatLng(0.0, 180.0), 0.0))
-      val latLngs = listOf(
-        mapboxMap.getLatLngFromScreenCoords(0f, 0f),
-        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, 0f),
-        mapboxMap.getLatLngFromScreenCoords(mapView.width.toFloat(), 0f)
-          .also { it.longitude += 360 },
-        mapboxMap.getLatLngFromScreenCoords(mapView.width.toFloat(), mapView.height / 2f)
-          .also { it.longitude += 360 },
-        mapboxMap.getLatLngFromScreenCoords(mapView.width.toFloat(), mapView.height.toFloat())
-          .also { it.longitude += 360 },
-        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height.toFloat()),
-        mapboxMap.getLatLngFromScreenCoords(0f, mapView.height.toFloat()),
-        mapboxMap.getLatLngFromScreenCoords(0f, mapView.height / 2f),
-        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f)
-      )
-      val visibleRegion = mapboxMap.projection.visibleRegion
-      assertTrue(latLngs.all { visibleRegion.latLngBounds.contains(it) })
-    }
-  }
-
-  @Test
   fun paddedVisibleRegionOverDatelineTest() {
     validateTestSetup()
     invoke(mapboxMap) { _: UiController, mapboxMap: MapboxMap ->
@@ -471,32 +447,6 @@ class VisibleRegionTest : BaseTest() {
   }
 
   @Test
-  fun visibleRegionBoundsOverDatelineBigSizeRegionTest() {
-    validateTestSetup()
-    invoke(mapboxMap) { _: UiController, mapboxMap: MapboxMap ->
-      mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(LatLng(0.0, -180.0), 0.0))
-      val latLngs = listOf(
-        mapboxMap.getLatLngFromScreenCoords(0f, 0f),
-        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, 0f),
-        mapboxMap.getLatLngFromScreenCoords(mapView.width.toFloat(), 0f)
-          .also { it.longitude += 360 },
-        mapboxMap.getLatLngFromScreenCoords(mapView.width.toFloat(), mapView.height / 2f)
-          .also { it.longitude += 360 },
-        mapboxMap.getLatLngFromScreenCoords(mapView.width.toFloat(), mapView.height.toFloat())
-          .also { it.longitude += 360 },
-        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height.toFloat()),
-        mapboxMap.getLatLngFromScreenCoords(0f, mapView.height.toFloat()),
-        mapboxMap.getLatLngFromScreenCoords(0f, mapView.height / 2f),
-        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f)
-      )
-      val bounds = doubleArrayOf(0.0, 0.0, 0.0, 0.0)
-      mapboxMap.projection.getVisibleCoordinateBounds(bounds)
-      val latLngBounds = LatLngBounds.from(bounds[0], bounds[1], bounds[2], bounds[3])
-      assertTrue(latLngs.all { latLngBounds.contains(it) })
-    }
-  }
-
-  @Test
   fun visibleRegionBoundsOverDatelineLatitudeZeroTest() {
     validateTestSetup()
     invoke(mapboxMap) { _: UiController, mapboxMap: MapboxMap ->
@@ -542,13 +492,12 @@ class VisibleRegionTest : BaseTest() {
   fun visibleRotatedRegionBoundsOverDatelineTest() {
     validateTestSetup()
     invoke(mapboxMap) { _: UiController, mapboxMap: MapboxMap ->
-      mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(LatLng(0.0, 180.0), 8.0))
+      mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(LatLng(0.0, 179.0), 8.0))
       val d = Math.min(mapboxMap.width, mapboxMap.height) / 4
       val latLngs = listOf(
         mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f),
         mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f - d / 2f, mapView.height / 2f),
-        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f + d / 2f, mapView.height / 2f)
-          .also { it.longitude += 360 },
+        mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f + d / 2f, mapView.height / 2f),
         mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f - d / 2f),
         mapboxMap.getLatLngFromScreenCoords(mapView.width / 2f, mapView.height / 2f + d / 2f)
       )


### PR DESCRIPTION
Resolves https://github.com/mapbox/mapbox-gl-native-android/issues/81 , refs https://github.com/mapbox/mapbox-gl-native/pull/16069

This PR add `void getVisibleCoordinateBounds(@NonNull double[] bounds)` method to get visible screen coordinate bounds in an array.