### PR TITLE
[docs] 8.5.2 changelog release-sangria cherrypick to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 ### Bug fixes
  - Synchronise LibaryLoader#loadLibrary to avoid race conditions resulting in UnsatisfiedLinkError [#58](https://github.com/mapbox/mapbox-gl-native-android/pull/58)
 
+## 8.5.2 - December 10, 2019
+[Changes](https://github.com/mapbox/mapbox-gl-native-android/compare/android-v8.5.1...android-v8.5.2) since [Mapbox Maps SDK for Android v8.5.1](https://github.com/mapbox/mapbox-gl-native-android/releases/tag/android-v8.5.1):
+
+### Features
+- Enabling decoupling vacuum operation from other operations run on the offline database file (delete offline region, clear ambient cache) [#99](https://github.com/mapbox/mapbox-gl-native-android/pull/99)
+
 ## 8.5.1 - November 20, 2019
 [Changes](https://github.com/mapbox/mapbox-gl-native-android/compare/android-v8.5.0...android-v8.5.1) since [Mapbox Maps SDK for Android v8.5.0](https://github.com/mapbox/mapbox-gl-native-android/releases/tag/android-v8.5.0):
 ### Bugs


### PR DESCRIPTION
This pr cherry picks _only_ the changelog update for the `8.5.2` patch release of `release-sangria`. https://github.com/mapbox/mapbox-gl-native-android/pull/99/files