### PR TITLE
Release v8.6.0 tequila final

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Mapbox welcomes participation and contributions from everyone.  If you'd like to do so please see the [`Contributing Guide`](https://github.com/mapbox/mapbox-gl-native/blob/master/CONTRIBUTING.md) first to get started.
 
+## 8.6.0 - December 20, 2019
+### Bug fixes
+ - Revert of a commit that resulted in a native crash when cycle debug options was invoked, issue was only impacting v8.6.0-beta.1 [#16074](https://github.com/mapbox/mapbox-gl-native/pull/16074)
+ - Fixed a crash caused by an unintentional minification of the `LocalGlyphRasterizer`. The full class definition is now kept when minification is used by end developer [#102](https://github.com/mapbox/mapbox-gl-native-android/pull/102)
+ - Fixed intermittent offline download failures by clearing the batch buffer if a download is interrupted. [#16074](https://github.com/mapbox/mapbox-gl-native/pull/16074)
+ - Fixed error for excessively overscaled lines [#16045](https://github.com/mapbox/mapbox-gl-native/pull/16045)
+ - Fixed signed to unsigned implicit conversion errors in symbol placement. [#16008](https://github.com/mapbox/mapbox-gl-native/pull/16008)
+ - Fixed error that would result when 0.0 was passed into `text-size` [#16080](https://github.com/mapbox/mapbox-gl-native/pull/16080)
+
 ## 8.6.0-beta.1 - December 6, 2019
 [Changes](https://github.com/mapbox/mapbox-gl-native/compare/android-v8.6.0-alpha.2...android-v8.6.0-beta.1) since [Mapbox Maps SDK for Android v8.6.0-alpha.2](https://github.com/mapbox/mapbox-gl-native/releases/tag/android-v8.6.0-alpha.2):
 ### Features
@@ -22,7 +31,7 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 ## 8.6.0-alpha.2 - November 22, 2019
 [Changes](https://github.com/mapbox/mapbox-gl-native/compare/android-v8.6.0-alpha.1...android-v8.6.0-alpha.2) since [Mapbox Maps SDK for Android v8.6.0-alpha.1](https://github.com/mapbox/mapbox-gl-native/releases/tag/android-v8.6.0-alpha.1):
 
-### Bugs
+### Bug fixes
  - Synchronise LibaryLoader#loadLibrary to avoid race conditions resulting in UnsatisfiedLinkError [#58](https://github.com/mapbox/mapbox-gl-native-android/pull/58)
 
 ## 8.5.1 - November 20, 2019

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/text/LocalGlyphRasterizer.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/text/LocalGlyphRasterizer.java
@@ -14,6 +14,7 @@ import android.support.annotation.WorkerThread;
  * LocalGlyphRasterizer is the Android-specific platform implementation used
  * by the portable local_glyph_rasterizer.hpp
  */
+@Keep
 public class LocalGlyphRasterizer {
   private final Bitmap bitmap;
   @NonNull
@@ -49,7 +50,6 @@ public class LocalGlyphRasterizer {
    * @return Return a {@link Bitmap} to be displayed in the requested tile.
    */
   @WorkerThread
-  @Keep
   protected Bitmap drawGlyphBitmap(String fontFamily, boolean bold, char glyphID) {
     paint.setTypeface(Typeface.create(fontFamily, bold ? Typeface.BOLD : Typeface.NORMAL));
     canvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);


### PR DESCRIPTION
This PR prepares the `release-tequila` branch for final release. 
 - updates mapbox-gl-native module to tip of upstream `release-tequila`
 - cherry pick of https://github.com/mapbox/mapbox-gl-native-android/pull/102
 - update changelog with above items