### PR TITLE
Update major version number to 9

### DIFF
--- a/MapboxGLAndroidSDK/gradle.properties
+++ b/MapboxGLAndroidSDK/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=8.6.0-SNAPSHOT
+VERSION_NAME=9.0.0-SNAPSHOT
 
 # Only build native dependencies for the current ABI
 # See https://code.google.com/p/android/issues/detail?id=221098#c20


### PR DESCRIPTION
With https://github.com/mapbox/mapbox-gl-native-android/pull/129, we are upgrading to AndroidX. This results in bumping the major version number as we are now consuming different dependencies. 