### PR TITLE
Update javadoc of setResourceCachePath

### DIFF
--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/storage/FileSource.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/storage/FileSource.java
@@ -261,10 +261,10 @@ public class FileSource {
 
   /**
    * Changes the path of the resources cache database.
-   * Note that the external storage setting needs to be activated in the manifest.
    * <p>
    * The callback reference is <b>strongly kept</b> throughout the process,
    * so it needs to be wrapped in a weak reference or released on the client side if necessary.
+   * </p>
    *
    * @param context  the context of the path
    * @param path     the new database path
@@ -280,10 +280,10 @@ public class FileSource {
 
   /**
    * Changes the path of the resources cache database.
-   * Note that the external storage setting needs to be activated in the manifest.
    * <p>
    * The callback reference is <b>strongly kept</b> throughout the process,
    * so it needs to be wrapped in a weak reference or released on the client side if necessary.
+   * </p>
    *
    * @param path     the new database path
    * @param callback the callback to obtain the result

--- a/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
+++ b/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
@@ -1026,6 +1026,7 @@
             android:value="pk.eyJ1IjoiYmxzdGFnaW5nIiwiYSI6ImNpdDF3OHpoaTAwMDcyeXA5Y3Z0Nmk2dzEifQ.0IfB7v5Qbm2MGVYt8Kb8fg" />
 
         <!-- Comment out this setting to switch to external storage (and disable internal) in your app -->
+        <!-- Alternatively you can rely on FileSource#setResourceCachePath API instead -->
         <!-- <meta-data -->
         <!-- android:name="com.mapbox.SetStorageExternal" -->
         <!-- android:value="true" /> -->


### PR DESCRIPTION
Capturing from @LukasPaczos that we don't need:

```xml
         <meta-data 
            android:name="com.mapbox.SetStorageExternal" 
            android:value="true" /> 
```

to execute `FileSource#setResourceCachePath()` anymore.
Updating the javadoc to reflect this. 