### PR TITLE
AccountManager: write user ID synchronously, keep it in memory.

### DIFF
--- a/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/AccountsManagerTest.java
+++ b/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/AccountsManagerTest.java
@@ -4,6 +4,8 @@ import android.content.SharedPreferences;
 import android.text.format.DateUtils;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import static com.mapbox.mapboxsdk.constants.MapboxConstants.KEY_PREFERENCE_SKU_TOKEN;
 import static org.junit.Assert.assertEquals;
@@ -13,6 +15,7 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@RunWith(RobolectricTestRunner.class)
 public class AccountsManagerTest {
   @Test
   public void testIsExpired() {


### PR DESCRIPTION
- write user ID synchronously in order to avoid potential side effects (use commit() instead of apply());
- cache `userId` (as class member); if it fails to save shared preferences (`insufficient storage` error or whatever), at least we have app life-time user ID;
- getSkuToken() is used from different thread (by http stack), so lets move all interaction with user id property to `synchronized` method;