### PR TITLE
Expose pixel ratio as public API on MapView

### DIFF
--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -542,7 +542,13 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     }
   }
 
-  private float getPixelRatio() {
+  /**
+   * Returns the map pixel ratio, by default it returns the device pixel ratio.
+   * Can be overwritten using {@link MapboxMapOptions#pixelRatio(float)}.
+   *
+   * @return the current map pixel ratio
+   */
+  public float getPixelRatio() {
     // check is user defined his own pixel ratio value
     float pixelRatio = mapboxMapOptions.getPixelRatio();
     if (pixelRatio == 0) {


### PR DESCRIPTION
This PR promotes the pixel ratio API to public (from private). Plugins/Developers should be able to reference the configured value. Refs https://github.com/mapbox/mapbox-plugins-android/issues/1075