### PR TITLE
Expose option to pass intermediate points for smooth location animation

### DIFF
--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/MapboxAnimator.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/MapboxAnimator.java
@@ -4,8 +4,10 @@ import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
 import android.animation.TypeEvaluator;
 import android.animation.ValueAnimator;
+
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
+import androidx.annotation.Size;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -48,13 +50,13 @@ abstract class MapboxAnimator<K> extends ValueAnimator implements ValueAnimator.
   private final double minUpdateInterval;
   private long timeElapsed;
 
-  MapboxAnimator(@NonNull K previous, @NonNull K target, @NonNull AnimationsValueChangeListener<K> updateListener,
+  MapboxAnimator(@NonNull @Size(min = 2) K[] values, @NonNull AnimationsValueChangeListener<K> updateListener,
                  int maxAnimationFps) {
     minUpdateInterval = 1E9 / maxAnimationFps;
-    setObjectValues(previous, target);
+    setObjectValues((Object[]) values);
     setEvaluator(provideEvaluator());
     this.updateListener = updateListener;
-    this.target = target;
+    this.target = values[values.length - 1];
     addUpdateListener(this);
     addListener(new AnimatorListener());
   }

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/MapboxAnimatorProvider.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/MapboxAnimatorProvider.java
@@ -20,21 +20,19 @@ final class MapboxAnimatorProvider {
     return INSTANCE;
   }
 
-  MapboxLatLngAnimator latLngAnimator(LatLng previous, LatLng target,
-                                      MapboxAnimator.AnimationsValueChangeListener updateListener,
+  MapboxLatLngAnimator latLngAnimator(LatLng[] values, MapboxAnimator.AnimationsValueChangeListener updateListener,
                                       int maxAnimationFps) {
-    return new MapboxLatLngAnimator(previous, target, updateListener, maxAnimationFps);
+    return new MapboxLatLngAnimator(values, updateListener, maxAnimationFps);
   }
 
-  MapboxFloatAnimator floatAnimator(Float previous, Float target,
-                                    MapboxAnimator.AnimationsValueChangeListener updateListener,
+  MapboxFloatAnimator floatAnimator(Float[] values, MapboxAnimator.AnimationsValueChangeListener updateListener,
                                     int maxAnimationFps) {
-    return new MapboxFloatAnimator(previous, target, updateListener, maxAnimationFps);
+    return new MapboxFloatAnimator(values, updateListener, maxAnimationFps);
   }
 
-  MapboxCameraAnimatorAdapter cameraAnimator(Float previous, Float target,
+  MapboxCameraAnimatorAdapter cameraAnimator(Float[] values,
                                              MapboxAnimator.AnimationsValueChangeListener updateListener,
                                              @Nullable MapboxMap.CancelableCallback cancelableCallback) {
-    return new MapboxCameraAnimatorAdapter(previous, target, updateListener, cancelableCallback);
+    return new MapboxCameraAnimatorAdapter(values, updateListener, cancelableCallback);
   }
 }

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/MapboxCameraAnimatorAdapter.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/MapboxCameraAnimatorAdapter.java
@@ -2,7 +2,10 @@ package com.mapbox.mapboxsdk.location;
 
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
+
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.Size;
 
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 
@@ -10,10 +13,10 @@ class MapboxCameraAnimatorAdapter extends MapboxFloatAnimator {
   @Nullable
   private final MapboxMap.CancelableCallback cancelableCallback;
 
-  MapboxCameraAnimatorAdapter(Float previous, Float target,
+  MapboxCameraAnimatorAdapter(@NonNull @Size(min = 2) Float[] values,
                               AnimationsValueChangeListener updateListener,
                               @Nullable MapboxMap.CancelableCallback cancelableCallback) {
-    super(previous, target, updateListener, Integer.MAX_VALUE);
+    super(values, updateListener, Integer.MAX_VALUE);
     this.cancelableCallback = cancelableCallback;
     addListener(new MapboxAnimatorListener());
   }

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/MapboxFloatAnimator.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/MapboxFloatAnimator.java
@@ -2,11 +2,14 @@ package com.mapbox.mapboxsdk.location;
 
 import android.animation.FloatEvaluator;
 import android.animation.TypeEvaluator;
+
 import androidx.annotation.NonNull;
+import androidx.annotation.Size;
 
 class MapboxFloatAnimator extends MapboxAnimator<Float> {
-  MapboxFloatAnimator(Float previous, Float target, AnimationsValueChangeListener updateListener, int maxAnimationFps) {
-    super(previous, target, updateListener, maxAnimationFps);
+  MapboxFloatAnimator(@NonNull @Size(min = 2) Float[] values,
+                      @NonNull AnimationsValueChangeListener updateListener, int maxAnimationFps) {
+    super(values, updateListener, maxAnimationFps);
   }
 
   @NonNull

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/MapboxLatLngAnimator.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/MapboxLatLngAnimator.java
@@ -1,15 +1,16 @@
 package com.mapbox.mapboxsdk.location;
 
 import android.animation.TypeEvaluator;
+
 import androidx.annotation.NonNull;
 
 import com.mapbox.mapboxsdk.geometry.LatLng;
 
 class MapboxLatLngAnimator extends MapboxAnimator<LatLng> {
 
-  MapboxLatLngAnimator(LatLng previous, LatLng target, AnimationsValueChangeListener updateListener,
+  MapboxLatLngAnimator(@NonNull LatLng[] values, @NonNull AnimationsValueChangeListener updateListener,
                        int maxAnimationFps) {
-    super(previous, target, updateListener, maxAnimationFps);
+    super(values, updateListener, maxAnimationFps);
   }
 
   @NonNull

--- a/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinatorTest.kt
+++ b/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinatorTest.kt
@@ -56,34 +56,32 @@ class LocationAnimatorCoordinatorTest {
     // workaround https://github.com/mockk/mockk/issues/229#issuecomment-457816131
     registerInstanceFactory { AnimationsValueChangeListener<Float> {} }
     registerInstanceFactory { AnimationsValueChangeListener<LatLng> {} }
-    val previousFloatSlot = slot<Float>()
-    val targetFloatSlot = slot<Float>()
+    val floatsSlot = slot<Array<Float>>()
     val listenerSlot = slot<MapboxAnimator.AnimationsValueChangeListener<*>>()
     val maxFpsSlot = slot<Int>()
     every {
-      animatorProvider.floatAnimator(capture(previousFloatSlot), capture(targetFloatSlot), capture(listenerSlot), capture(maxFpsSlot))
+      animatorProvider.floatAnimator(capture(floatsSlot), capture(listenerSlot), capture(maxFpsSlot))
     } answers {
-      MapboxFloatAnimator(previousFloatSlot.captured, targetFloatSlot.captured, listenerSlot.captured, maxFpsSlot.captured)
+      MapboxFloatAnimator(floatsSlot.captured, listenerSlot.captured, maxFpsSlot.captured)
     }
 
-    val previousLatLngSlot = slot<LatLng>()
-    val targetLatLngSlot = slot<LatLng>()
+    val latLngsSlot = slot<Array<LatLng>>()
     every {
-      animatorProvider.latLngAnimator(capture(previousLatLngSlot), capture(targetLatLngSlot), capture(listenerSlot), capture(maxFpsSlot))
+      animatorProvider.latLngAnimator(capture(latLngsSlot), capture(listenerSlot), capture(maxFpsSlot))
     } answers {
-      MapboxLatLngAnimator(previousLatLngSlot.captured, targetLatLngSlot.captured, listenerSlot.captured, maxFpsSlot.captured)
+      MapboxLatLngAnimator(latLngsSlot.captured, listenerSlot.captured, maxFpsSlot.captured)
     }
 
     val callback = slot<MapboxMap.CancelableCallback>()
     every {
-      animatorProvider.cameraAnimator(capture(previousFloatSlot), capture(targetFloatSlot), capture(listenerSlot), capture(callback))
+      animatorProvider.cameraAnimator(capture(floatsSlot), capture(listenerSlot), capture(callback))
     } answers {
-      MapboxCameraAnimatorAdapter(previousFloatSlot.captured, targetFloatSlot.captured, listenerSlot.captured, callback.captured)
+      MapboxCameraAnimatorAdapter(floatsSlot.captured, listenerSlot.captured, callback.captured)
     }
     every {
-      animatorProvider.cameraAnimator(capture(previousFloatSlot), capture(targetFloatSlot), capture(listenerSlot), null)
+      animatorProvider.cameraAnimator(capture(floatsSlot), capture(listenerSlot), null)
     } answers {
-      MapboxCameraAnimatorAdapter(previousFloatSlot.captured, targetFloatSlot.captured, listenerSlot.captured, null)
+      MapboxCameraAnimatorAdapter(floatsSlot.captured, listenerSlot.captured, null)
     }
   }
 
@@ -106,16 +104,112 @@ class LocationAnimatorCoordinatorTest {
     locationAnimatorCoordinator.feedNewLocation(location, cameraPosition, false)
 
     val cameraLatLngTarget = locationAnimatorCoordinator.animatorArray[ANIMATOR_CAMERA_LATLNG]?.target as LatLng
-    assertEquals(cameraLatLngTarget.latitude, cameraLatLngTarget.latitude)
+    assertEquals(location.latitude, cameraLatLngTarget.latitude)
+    assertEquals(location.longitude, cameraLatLngTarget.longitude)
 
     val layerLatLngTarget = locationAnimatorCoordinator.animatorArray[ANIMATOR_LAYER_LATLNG]?.target as LatLng
-    assertEquals(layerLatLngTarget.latitude, layerLatLngTarget.latitude)
+    assertEquals(location.latitude, layerLatLngTarget.latitude)
+    assertEquals(location.longitude, layerLatLngTarget.longitude)
 
     val cameraBearingTarget = locationAnimatorCoordinator.animatorArray[ANIMATOR_CAMERA_GPS_BEARING]?.target as Float
     assertEquals(location.bearing, cameraBearingTarget)
 
     val layerBearingTarget = locationAnimatorCoordinator.animatorArray[ANIMATOR_LAYER_GPS_BEARING]?.target as Float
     assertEquals(location.bearing, layerBearingTarget)
+  }
+
+  @Test
+  fun feedNewLocation_animatorValue_multiplePoints() {
+    val previousLocation = Location("")
+    previousLocation.latitude = 0.0
+    previousLocation.longitude = 0.0
+    previousLocation.bearing = 0f
+
+    val locationInter = Location("")
+    locationInter.latitude = 51.1
+    locationInter.longitude = 17.1
+    locationInter.bearing = 35f
+    val location = Location("")
+    location.latitude = 51.2
+    location.longitude = 17.2
+    location.bearing = 36f
+    locationAnimatorCoordinator.feedNewLocation(arrayOf(locationInter, location), cameraPosition, false, false)
+
+    val cameraLatLngTarget = locationAnimatorCoordinator.animatorArray[ANIMATOR_CAMERA_LATLNG]?.target as LatLng
+    assertEquals(location.latitude, cameraLatLngTarget.latitude)
+    assertEquals(location.longitude, cameraLatLngTarget.longitude)
+
+    val layerLatLngTarget = locationAnimatorCoordinator.animatorArray[ANIMATOR_LAYER_LATLNG]?.target as LatLng
+    assertEquals(location.latitude, layerLatLngTarget.latitude)
+    assertEquals(location.longitude, layerLatLngTarget.longitude)
+
+    val cameraBearingTarget = locationAnimatorCoordinator.animatorArray[ANIMATOR_CAMERA_GPS_BEARING]?.target as Float
+    assertEquals(location.bearing, cameraBearingTarget)
+
+    val layerBearingTarget = locationAnimatorCoordinator.animatorArray[ANIMATOR_LAYER_GPS_BEARING]?.target as Float
+    assertEquals(location.bearing, layerBearingTarget)
+
+    verify {
+      animatorProvider.latLngAnimator(
+        arrayOf(
+          LatLng(previousLocation.latitude, previousLocation.longitude),
+          LatLng(locationInter.latitude, locationInter.longitude),
+          LatLng(location.latitude, location.longitude)
+        ), any(), any()
+      )
+    }
+    verify {
+      animatorProvider.floatAnimator(
+        arrayOf(previousLocation.bearing, locationInter.bearing, location.bearing), any(), any()
+      )
+    }
+  }
+
+  @Test
+  fun feedNewLocation_animatorValue_multiplePoints_animationDuration() {
+    every { projection.getMetersPerPixelAtLatitude(any()) } answers { 10000.0 } // disable snap
+    val locationInter = Location("")
+    locationInter.latitude = 51.1
+    locationInter.longitude = 17.1
+    locationInter.bearing = 35f
+    val location = Location("")
+    location.latitude = 51.2
+    location.longitude = 17.2
+    location.bearing = 36f
+    locationAnimatorCoordinator.feedNewLocation(arrayOf(locationInter, location), cameraPosition, false, false)
+
+    verify {
+      animatorSetProvider.startAnimation(eq(listOf(
+        locationAnimatorCoordinator.animatorArray[ANIMATOR_LAYER_LATLNG],
+        locationAnimatorCoordinator.animatorArray[ANIMATOR_LAYER_GPS_BEARING],
+        locationAnimatorCoordinator.animatorArray[ANIMATOR_CAMERA_LATLNG],
+        locationAnimatorCoordinator.animatorArray[ANIMATOR_CAMERA_GPS_BEARING]
+      )), any<LinearInterpolator>(), 0)
+    }
+  }
+
+  @Test
+  fun feedNewLocation_animatorValue_multiplePoints_animationDuration_lookAhead() {
+    every { projection.getMetersPerPixelAtLatitude(any()) } answers { 10000.0 } // disable snap
+    val locationInter = Location("")
+    locationInter.latitude = 51.1
+    locationInter.longitude = 17.1
+    locationInter.bearing = 35f
+    val location = Location("")
+    location.latitude = 51.2
+    location.longitude = 17.2
+    location.bearing = 36f
+    location.time = System.currentTimeMillis() + 2000
+    locationAnimatorCoordinator.feedNewLocation(arrayOf(locationInter, location), cameraPosition, false, true)
+
+    verify {
+      animatorSetProvider.startAnimation(eq(listOf(
+        locationAnimatorCoordinator.animatorArray[ANIMATOR_LAYER_LATLNG],
+        locationAnimatorCoordinator.animatorArray[ANIMATOR_LAYER_GPS_BEARING],
+        locationAnimatorCoordinator.animatorArray[ANIMATOR_CAMERA_LATLNG],
+        locationAnimatorCoordinator.animatorArray[ANIMATOR_CAMERA_GPS_BEARING]
+      )), any<LinearInterpolator>(), more(1500L))
+    }
   }
 
   @Test
@@ -508,8 +602,8 @@ class LocationAnimatorCoordinatorTest {
   fun maxFps_givenToAnimator() {
     locationAnimatorCoordinator.setMaxAnimationFps(5)
     locationAnimatorCoordinator.feedNewLocation(Location(""), cameraPosition, false)
-    verify { animatorProvider.latLngAnimator(any(), any(), any(), 5) }
-    verify { animatorProvider.floatAnimator(any(), any(), any(), 5) }
+    verify { animatorProvider.latLngAnimator(any(), any(), 5) }
+    verify { animatorProvider.floatAnimator(any(), any(), 5) }
   }
 
   private fun getListenerHoldersSet(vararg animatorTypes: Int): Set<AnimatorListenerHolder> {

--- a/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/MapboxAnimatorTest.kt
+++ b/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/MapboxAnimatorTest.kt
@@ -17,7 +17,7 @@ class MapboxAnimatorTest {
     every { valueAnimator.animatedValue } answers { 5f }
     val listener = mockk<MapboxAnimator.AnimationsValueChangeListener<Float>>()
     every { listener.onNewAnimationValue(any()) } answers {}
-    val mapboxAnimator = MapboxFloatAnimator(0f, 10f, listener, Int.MAX_VALUE)
+    val mapboxAnimator = MapboxFloatAnimator(floatArrayOf(0f, 10f).toTypedArray(), listener, Int.MAX_VALUE)
 
     for (i in 0 until 5)
       mapboxAnimator.onAnimationUpdate(valueAnimator)
@@ -31,7 +31,7 @@ class MapboxAnimatorTest {
     every { valueAnimator.animatedValue } answers { 5f }
     val listener = mockk<MapboxAnimator.AnimationsValueChangeListener<Float>>()
     every { listener.onNewAnimationValue(any()) } answers {}
-    val mapboxAnimator = MapboxFloatAnimator(0f, 10f, listener, 5)
+    val mapboxAnimator = MapboxFloatAnimator(floatArrayOf(0f, 10f).toTypedArray(), listener, 5)
 
     for (i in 0 until 5) {
       mapboxAnimator.onAnimationUpdate(valueAnimator)


### PR DESCRIPTION
This PR adds a `LocationComponent#forceLocation` overload, which allows passing a list of locations. The last location in the list is the desired target, while everything else makes up for the intermediate points in the otherwise linear location puck animation. This allows for better road geometry tracking and avoids "cutting" corners when 2 raw updates are on the opposite side of an intersection maneuver.

This also exposes a `lookAheadUpdate` flag in the same method. If we have an ability to predict location updates, setting this flag to `true` will take the timestamp of the target location (last in the list) and calculate the animation duration equal to
```
targetLocationTimestamp - currentTimestamp
```
This allows minimizing the visual lag that a smooth animation would introduce otherwise.

/cc @SiarheiFedartsou @mskurydin 