### PR TITLE
Add clear callback methods

### DIFF
--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/CameraChangeDispatcher.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/CameraChangeDispatcher.java
@@ -72,6 +72,10 @@ class CameraChangeDispatcher implements MapboxMap.OnCameraMoveStartedListener, M
     }
   }
 
+  void clearOnCameraIdleListeners() {
+    onCameraIdle.clear();
+  }
+
   void addOnCameraMoveCancelListener(OnCameraMoveCanceledListener listener) {
     onCameraMoveCanceled.add(listener);
   }

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/CameraChangeDispatcher.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/CameraChangeDispatcher.java
@@ -100,6 +100,10 @@ class CameraChangeDispatcher implements MapboxMap.OnCameraMoveStartedListener, M
     }
   }
 
+  void clearOnCameraMoveStartedListeners() {
+    onCameraMoveStarted.clear();
+  }
+
   void addOnCameraMoveListener(OnCameraMoveListener listener) {
     onCameraMove.add(listener);
   }

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/CameraChangeDispatcher.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/CameraChangeDispatcher.java
@@ -86,6 +86,10 @@ class CameraChangeDispatcher implements MapboxMap.OnCameraMoveStartedListener, M
     }
   }
 
+  void clearOnCameraMoveCancelListeners() {
+    onCameraMoveCanceled.clear();
+  }
+
   void addOnCameraMoveStartedListener(OnCameraMoveStartedListener listener) {
     onCameraMoveStarted.add(listener);
   }

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/CameraChangeDispatcher.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/CameraChangeDispatcher.java
@@ -114,6 +114,10 @@ class CameraChangeDispatcher implements MapboxMap.OnCameraMoveStartedListener, M
     }
   }
 
+  void clearOnCameraMoveListeners() {
+    onCameraMove.clear();
+  }
+
   private void executeOnCameraMoveStarted() {
     if (!idle) {
       return;

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
@@ -1119,6 +1119,10 @@ final class MapGestureDetector {
     onFlingListenerList.remove(onFlingListener);
   }
 
+  void clearOnFlingListeners() {
+    onFlingListenerList.clear();
+  }
+
   void addOnMoveListener(MapboxMap.OnMoveListener listener) {
     onMoveListenerList.add(listener);
   }

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
@@ -1167,6 +1167,10 @@ final class MapGestureDetector {
     onShoveListenerList.remove(listener);
   }
 
+  void clearShoveListeners() {
+    onShoveListenerList.clear();
+  }
+
   AndroidGesturesManager getGesturesManager() {
     return gesturesManager;
   }

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
@@ -1107,6 +1107,10 @@ final class MapGestureDetector {
     onMapLongClickListenerList.remove(onMapLongClickListener);
   }
 
+  void clearOnMapLongClickListeners() {
+    onMapLongClickListenerList.clear();
+  }
+
   void addOnFlingListener(MapboxMap.OnFlingListener onFlingListener) {
     onFlingListenerList.add(onFlingListener);
   }

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
@@ -1095,6 +1095,10 @@ final class MapGestureDetector {
     onMapClickListenerList.remove(onMapClickListener);
   }
 
+  void clearOnMapClickListeners() {
+    onMapClickListenerList.clear();
+  }
+
   void addOnMapLongClickListener(MapboxMap.OnMapLongClickListener onMapLongClickListener) {
     onMapLongClickListenerList.add(onMapLongClickListener);
   }

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
@@ -1155,6 +1155,10 @@ final class MapGestureDetector {
     onScaleListenerList.remove(listener);
   }
 
+  void clearOnScaleListeners() {
+    onScaleListenerList.clear();
+  }
+
   void addShoveListener(MapboxMap.OnShoveListener listener) {
     onShoveListenerList.add(listener);
   }

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
@@ -1131,6 +1131,10 @@ final class MapGestureDetector {
     onMoveListenerList.remove(listener);
   }
 
+  void clearOnMoveListeners() {
+    onMoveListenerList.clear();
+  }
+
   void addOnRotateListener(MapboxMap.OnRotateListener listener) {
     onRotateListenerList.add(listener);
   }

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
@@ -1143,6 +1143,10 @@ final class MapGestureDetector {
     onRotateListenerList.remove(listener);
   }
 
+  void clearOnRotateListeners() {
+    onRotateListenerList.clear();
+  }
+
   void addOnScaleListener(MapboxMap.OnScaleListener listener) {
     onScaleListenerList.add(listener);
   }

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -1241,6 +1241,11 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     }
 
     @Override
+    public void onClearRotateListeners() {
+      mapGestureDetector.clearOnRotateListeners();
+    }
+
+    @Override
     public void onAddScaleListener(MapboxMap.OnScaleListener listener) {
       mapGestureDetector.addOnScaleListener(listener);
     }

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -1191,6 +1191,11 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     }
 
     @Override
+    public void onClearMapLongClickListeners() {
+      mapGestureDetector.clearOnMapLongClickListeners();
+    }
+
+    @Override
     public void onRemoveMapLongClickListener(MapboxMap.OnMapLongClickListener listener) {
       mapGestureDetector.removeOnMapLongClickListener(listener);
     }

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -1181,6 +1181,11 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     }
 
     @Override
+    public void onClearMapClickListeners() {
+      mapGestureDetector.clearOnMapClickListeners();
+    }
+
+    @Override
     public void onAddMapLongClickListener(MapboxMap.OnMapLongClickListener listener) {
       mapGestureDetector.addOnMapLongClickListener(listener);
     }

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -1211,6 +1211,11 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     }
 
     @Override
+    public void onClearFlingListeners() {
+      mapGestureDetector.clearOnFlingListeners();
+    }
+
+    @Override
     public void onAddMoveListener(MapboxMap.OnMoveListener listener) {
       mapGestureDetector.addOnMoveListener(listener);
     }

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -1226,6 +1226,11 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     }
 
     @Override
+    public void onClearMoveListeners() {
+      mapGestureDetector.clearOnMoveListeners();
+    }
+
+    @Override
     public void onAddRotateListener(MapboxMap.OnRotateListener listener) {
       mapGestureDetector.addOnRotateListener(listener);
     }

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -1271,6 +1271,11 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     }
 
     @Override
+    public void onClearShoveListeners() {
+      mapGestureDetector.clearShoveListeners();
+    }
+
+    @Override
     public AndroidGesturesManager getGesturesManager() {
       return mapGestureDetector.getGesturesManager();
     }

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -1256,6 +1256,11 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     }
 
     @Override
+    public void onClearScaleListeners() {
+      mapGestureDetector.clearOnScaleListeners();
+    }
+
+    @Override
     public void onAddShoveListener(MapboxMap.OnShoveListener listener) {
       mapGestureDetector.addShoveListener(listener);
     }

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -1826,6 +1826,13 @@ public final class MapboxMap {
   }
 
   /**
+   * Clears callbacks that are invoked when the map is scaled.
+   */
+  public void clearOnScaleListeners() {
+    onGesturesManagerInteractionListener.onClearScaleListeners();
+  }
+
+  /**
    * Adds a callback that's invoked when the map is tilted.
    *
    * @param listener The callback that's invoked when the map is tilted.
@@ -2280,6 +2287,8 @@ public final class MapboxMap {
     void onAddScaleListener(OnScaleListener listener);
 
     void onRemoveScaleListener(OnScaleListener listener);
+
+    void onClearScaleListeners();
 
     void onAddShoveListener(OnShoveListener listener);
 

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -1876,6 +1876,13 @@ public final class MapboxMap {
   }
 
   /**
+   * Clears callbacks that are invoked when the user clicks on the map view.
+   */
+  public void clearOnMapClickListeners() {
+    onGesturesManagerInteractionListener.onClearMapClickListeners();
+  }
+
+  /**
    * Adds a callback that's invoked when the user long clicks on the map view.
    *
    * @param listener The callback that's invoked when the user long clicks on the map view.
@@ -2215,6 +2222,8 @@ public final class MapboxMap {
     void onAddMapClickListener(OnMapClickListener listener);
 
     void onRemoveMapClickListener(OnMapClickListener listener);
+
+    void onClearMapClickListeners();
 
     void onAddMapLongClickListener(OnMapLongClickListener listener);
 

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -1851,6 +1851,13 @@ public final class MapboxMap {
   }
 
   /**
+   * Clears callbacks that are invoked when the map is tilted.
+   */
+  public void clearOnShoveListeners() {
+    onGesturesManagerInteractionListener.onClearShoveListeners();
+  }
+
+  /**
    * Sets a custom {@link AndroidGesturesManager} to handle {@link android.view.MotionEvent}s
    * registered by the {@link MapView}.
    *
@@ -2293,6 +2300,8 @@ public final class MapboxMap {
     void onAddShoveListener(OnShoveListener listener);
 
     void onRemoveShoveListener(OnShoveListener listener);
+
+    void onClearShoveListeners();
 
     AndroidGesturesManager getGesturesManager();
 

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -1634,6 +1634,13 @@ public final class MapboxMap {
   }
 
   /**
+   * Clears callbacks that are invoked when camera movement has ended.
+   */
+  public void clearOnCameraIdleListeners() {
+    cameraChangeDispatcher.clearOnCameraIdleListeners();
+  }
+
+  /**
    * Adds a callback that is invoked when camera movement was cancelled.
    *
    * @param listener the listener to notify

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -1709,6 +1709,13 @@ public final class MapboxMap {
   }
 
   /**
+   * Clears callbacks that are invoked when camera position changes.
+   */
+  public void clearOnCameraMoveListeners() {
+    cameraChangeDispatcher.clearOnCameraMoveListeners();
+  }
+
+  /**
    * Sets a callback that's invoked on every frame rendered to the map view.
    *
    * @param listener The callback that's invoked on every frame rendered to the map view.

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -1684,6 +1684,13 @@ public final class MapboxMap {
   }
 
   /**
+   * Clears callbacks that are when camera movement has started.
+   */
+  public void clearOnCameraMoveStartedListeners() {
+    cameraChangeDispatcher.clearOnCameraMoveStartedListeners();
+  }
+
+  /**
    * Adds a callback that is invoked when camera position changes.
    *
    * @param listener the listener to notify

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -1901,6 +1901,13 @@ public final class MapboxMap {
   }
 
   /**
+   * Clears callbacks that are invoked when the user long clicks on the map view.
+   */
+  public void clearOnMapLongClickListeners() {
+    onGesturesManagerInteractionListener.onClearMapLongClickListeners();
+  }
+
+  /**
    * Sets a callback that's invoked when the user clicks on an info window.
    *
    * @param listener The callback that's invoked when the user clicks on an info window.
@@ -2226,6 +2233,8 @@ public final class MapboxMap {
     void onClearMapClickListeners();
 
     void onAddMapLongClickListener(OnMapLongClickListener listener);
+
+    void onClearMapLongClickListeners();
 
     void onRemoveMapLongClickListener(OnMapLongClickListener listener);
 

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -1776,6 +1776,13 @@ public final class MapboxMap {
   }
 
   /**
+   * Clears callbacks that are invoked when the map is moved.
+   */
+  public void clearOnMoveListeners() {
+    onGesturesManagerInteractionListener.onClearMoveListeners();
+  }
+
+  /**
    * Adds a callback that's invoked when the map is rotated.
    *
    * @param listener The callback that's invoked when the map is rotated.
@@ -2254,6 +2261,8 @@ public final class MapboxMap {
     void onAddMoveListener(OnMoveListener listener);
 
     void onRemoveMoveListener(OnMoveListener listener);
+
+    void onClearMoveListeners();
 
     void onAddRotateListener(OnRotateListener listener);
 

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -1659,6 +1659,13 @@ public final class MapboxMap {
   }
 
   /**
+   * Clears callbacks that are invoked when camera movement was cancelled.
+   */
+  public void clearOnCameraMoveCancelListeners() {
+    cameraChangeDispatcher.clearOnCameraMoveCancelListeners();
+  }
+
+  /**
    * Adds a callback that is invoked when camera movement has started.
    *
    * @param listener the listener to notify

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -1801,6 +1801,13 @@ public final class MapboxMap {
   }
 
   /**
+   * Clears callbacks that are invoked when the map is rotated.
+   */
+  public void clearOnRotateListeners() {
+    onGesturesManagerInteractionListener.onClearRotateListeners();
+  }
+
+  /**
    * Adds a callback that's invoked when the map is scaled.
    *
    * @param listener The callback that's invoked when the map is scaled.
@@ -2267,6 +2274,8 @@ public final class MapboxMap {
     void onAddRotateListener(OnRotateListener listener);
 
     void onRemoveRotateListener(OnRotateListener listener);
+
+    void onClearRotateListeners();
 
     void onAddScaleListener(OnScaleListener listener);
 

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -1751,6 +1751,13 @@ public final class MapboxMap {
   }
 
   /**
+   * Clears callbacks that are invoked when the map is flinged.
+   */
+  public void clearOnFlingListeners() {
+    onGesturesManagerInteractionListener.onClearFlingListeners();
+  }
+
+  /**
    * Adds a callback that's invoked when the map is moved.
    *
    * @param listener The callback that's invoked when the map is moved.
@@ -2241,6 +2248,8 @@ public final class MapboxMap {
     void onAddFlingListener(OnFlingListener listener);
 
     void onRemoveFlingListener(OnFlingListener listener);
+
+    void onClearFlingListeners();
 
     void onAddMoveListener(OnMoveListener listener);
 


### PR DESCRIPTION
This allows clearing out the added callbacks. The current use case is for setting up the map in observables, allowing the observer to be idempotent.