### PR TITLE
Add expression within

### DIFF
--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
@@ -12,6 +12,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+import com.mapbox.geojson.GeoJson;
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
 import com.mapbox.mapboxsdk.style.layers.PropertyValue;
 
@@ -1570,6 +1571,11 @@ public class Expression {
    */
   public static Expression in(@NonNull String needle, @NonNull Expression haystack) {
     return new Expression("in", literal(needle), haystack);
+  }
+
+  public static Expression within(@NonNull GeoJson geojson) {
+    String string = geojson.toJson();
+    return new Expression("within", literal(string));
   }
 
   /**

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
@@ -1,10 +1,6 @@
 package com.mapbox.mapboxsdk.style.expressions;
 
 import android.annotation.SuppressLint;
-import androidx.annotation.ColorInt;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.Size;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
@@ -12,7 +8,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
-import com.mapbox.geojson.GeoJson;
+import com.mapbox.geojson.Polygon;
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
 import com.mapbox.mapboxsdk.style.layers.PropertyValue;
 
@@ -22,6 +18,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+
+import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.Size;
 
 import static com.mapbox.mapboxsdk.utils.ColorUtils.colorToRgbaArray;
 
@@ -1540,8 +1541,8 @@ public class Expression {
   /**
    * Retrieves whether an item exists in an array or a substring exists in a string.
    *
-   * @param needle     the item expression
-   * @param haystack   the array or string expression
+   * @param needle   the item expression
+   * @param haystack the array or string expression
    * @return true if exists.
    * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-in">Style specification</a>
    */
@@ -1552,8 +1553,8 @@ public class Expression {
   /**
    * Retrieves whether an item exists in an array or a substring exists in a string.
    *
-   * @param needle     the item expression
-   * @param haystack   the array or string expression
+   * @param needle   the item expression
+   * @param haystack the array or string expression
    * @return true if exists.
    * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-in">Style specification</a>
    */
@@ -1564,8 +1565,8 @@ public class Expression {
   /**
    * Retrieves whether an item exists in an array or a substring exists in a string.
    *
-   * @param needle     the item expression
-   * @param haystack   the array or string expression
+   * @param needle   the item expression
+   * @param haystack the array or string expression
    * @return true if exists.
    * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-in">Style specification</a>
    */
@@ -1573,9 +1574,13 @@ public class Expression {
     return new Expression("in", literal(needle), haystack);
   }
 
-  public static Expression within(@NonNull GeoJson geojson) {
-    String string = geojson.toJson();
-    return new Expression("within", literal(string));
+  public static Expression within(@NonNull Polygon polygon) {
+    Map<String, Expression> map = new HashMap<>();
+
+    map.put("type", literal(polygon.type()));
+    map.put("json", literal(polygon.toJson()));
+
+    return new Expression("within", new ExpressionMap(map));
   }
 
   /**

--- a/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/style/expressions/ExpressionTest.java
+++ b/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/style/expressions/ExpressionTest.java
@@ -11,7 +11,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -473,7 +472,10 @@ public class ExpressionTest {
     );
 
     Polygon polygon = Polygon.fromLngLats(lngLats);
-    Object[] expected = new Object[] {"within", polygon};
+    HashMap<String, String> map = new HashMap<>();
+    map.put("type", "Polygon");
+    map.put("json", polygon.toJson());
+    Object[] expected = new Object[] {"within", map};
     Object[] actual = within(polygon).toArray();
     assertTrue("expression should match", Arrays.deepEquals(expected, actual));
   }

--- a/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/style/expressions/ExpressionTest.java
+++ b/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/style/expressions/ExpressionTest.java
@@ -2,6 +2,8 @@ package com.mapbox.mapboxsdk.style.expressions;
 
 import android.graphics.Color;
 
+import com.mapbox.geojson.Point;
+import com.mapbox.geojson.Polygon;
 import com.mapbox.mapboxsdk.style.layers.PropertyValue;
 import com.mapbox.mapboxsdk.utils.ColorUtils;
 
@@ -9,8 +11,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -94,6 +99,7 @@ import static com.mapbox.mapboxsdk.style.expressions.Expression.toRgba;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.typeOf;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.upcase;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.var;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.within;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.zoom;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineOpacity;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineWidth;
@@ -449,8 +455,26 @@ public class ExpressionTest {
 
   @Test
   public void testInString() throws Exception {
-    Object[] expected = new Object[] {"in", "one",  "onetwo"};
+    Object[] expected = new Object[] {"in", "one", "onetwo"};
     Object[] actual = in(literal("one"), literal("onetwo")).toArray();
+    assertTrue("expression should match", Arrays.deepEquals(expected, actual));
+  }
+
+  @Test
+  public void testWithIn() throws Exception {
+    List<List<Point>> lngLats = Collections.singletonList(
+      Arrays.asList(
+        Point.fromLngLat(0, 0),
+        Point.fromLngLat(0, 5),
+        Point.fromLngLat(5, 5),
+        Point.fromLngLat(5, 0),
+        Point.fromLngLat(0, 0)
+      )
+    );
+
+    Polygon polygon = Polygon.fromLngLats(lngLats);
+    Object[] expected = new Object[] {"within", polygon};
+    Object[] actual = within(polygon).toArray();
     assertTrue("expression should match", Arrays.deepEquals(expected, actual));
   }
 

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/RuntimeStyleActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/RuntimeStyleActivity.java
@@ -75,7 +75,6 @@ import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineWidth;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.symbolPlacement;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textSize;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.visibility;
-import static com.mapbox.mapboxsdk.utils.ColorUtils.colorToRgbaString;
 
 /**
  * Test activity showcasing the runtime style API.
@@ -88,14 +87,16 @@ public class RuntimeStyleActivity extends AppCompatActivity {
 
   List<List<Point>> lngLats = Collections.singletonList(
     Arrays.asList(
-      Point.fromLngLat(-13.359375,
-        67.60922060496382),
-      Point.fromLngLat(-14.0625,
-        36.1733569352216),
-      Point.fromLngLat(43.59375,
-        36.4566360115962),
-      Point.fromLngLat(-13.359375,
-        67.60922060496382)
+      Point.fromLngLat(-15.468749999999998,
+        41.77131167976407),
+      Point.fromLngLat(15.468749999999998,
+        41.77131167976407),
+      Point.fromLngLat(15.468749999999998,
+        58.26328705248601),
+      Point.fromLngLat(-15.468749999999998,
+        58.26328705248601),
+      Point.fromLngLat(-15.468749999999998,
+        41.77131167976407)
     )
   );
 
@@ -575,7 +576,7 @@ public class RuntimeStyleActivity extends AppCompatActivity {
         states.setProperties(
           textSize(switchCase(
             in(get("name"), literal("Texas")), literal(25.0f),
-            in(get("name"), literal(new Object[] {"California","Illinois"})), literal(25.0f),
+            in(get("name"), literal(new Object[] {"California", "Illinois"})), literal(25.0f),
             literal(6.0f) // default value
             )
           )

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/RuntimeStyleActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/RuntimeStyleActivity.java
@@ -73,6 +73,7 @@ import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineJoin;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineOpacity;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineWidth;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.symbolPlacement;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textOpacity;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textSize;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.visibility;
 
@@ -126,7 +127,7 @@ public class RuntimeStyleActivity extends AppCompatActivity {
           styleLoaded = true;
           SymbolLayer laber = (SymbolLayer) style.getLayer("country-label");
           laber.setProperties(
-            textSize(switchCase(within(polygon), literal(25f), literal(15f)))
+            textOpacity(switchCase(within(polygon), literal(1.0f), literal(0.5f)))
           );
         }
       );


### PR DESCRIPTION
Resolves #191 

This expression will cause error:
 ` E/Mbgl: {pboxsdk.testapp}[JNI]: Error setting property: text-size [1]: 'within' expression requires valid geojson source that contains polygon geometry type.` 

The error is triggered by `isObject` method return false  in this line https://github.com/mapbox/mapbox-gl-native/blob/9aefd2f2faf0e66afc263e96e3cff4cc03295e64/src/mbgl/style/expression/within.cpp#L111

The geojson passed into core is `{“type”:“Polygon”,“coordinates”:[[[-13.359375,67.6092206],[-14.0625,36.1733569],[43.59375,36.456636],[-13.359375,67.6092206]]]}` and @zmiao already confirmed that this geojson could pass glfw test.

@mapbox/maps-android any idea about this error?