### PR TITLE
Keep telemetry events in proguard

### DIFF
--- a/MapboxGLAndroidSDK/proguard-rules.pro
+++ b/MapboxGLAndroidSDK/proguard-rules.pro
@@ -27,6 +27,10 @@
 -keep class com.mapbox.geojson.** { *; }
 -dontwarn com.google.auto.value.**
 
+# config for telemetry events
+-keep class com.mapbox.mapboxsdk.module.telemetry.**
+-keep class com.mapbox.android.telemetry.**
+
 # config for additional notes
 -dontnote org.robolectric.Robolectric
 -dontnote libcore.io.Memory


### PR DESCRIPTION
This PR keeps telemetry events not being obfuscated, is part of https://github.com/mapbox/mapbox-gl-native-android/issues/210