### PR TITLE
Provide a way to opt out from LocationComponent initialisation

### DIFF
--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -13,12 +13,6 @@ import android.view.View;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
 
-import androidx.annotation.CallSuper;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.UiThread;
-import androidx.collection.LongSparseArray;
-
 import com.mapbox.android.gestures.AndroidGesturesManager;
 import com.mapbox.mapboxsdk.MapStrictMode;
 import com.mapbox.mapboxsdk.Mapbox;
@@ -42,6 +36,12 @@ import java.util.List;
 
 import javax.microedition.khronos.egl.EGLConfig;
 import javax.microedition.khronos.opengles.GL10;
+
+import androidx.annotation.CallSuper;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.UiThread;
+import androidx.collection.LongSparseArray;
 
 import static com.mapbox.mapboxsdk.maps.widgets.CompassView.TIME_MAP_NORTH_ANIMATION;
 import static com.mapbox.mapboxsdk.maps.widgets.CompassView.TIME_WAIT_IDLE;
@@ -175,7 +175,9 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
     mapKeyListener = new MapKeyListener(transform, uiSettings, mapGestureDetector);
 
     // LocationComponent
-    mapboxMap.injectLocationComponent(new LocationComponent(mapboxMap, transform, developerAnimationListeners));
+    if (mapboxMapOptions.getLocationComponentOptedIn()) {
+      mapboxMap.injectLocationComponent(new LocationComponent(mapboxMap, transform, developerAnimationListeners));
+    }
 
     // Ensure this view is interactable
     setClickable(true);

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -5,12 +5,6 @@ import android.graphics.Bitmap;
 import android.graphics.PointF;
 import android.graphics.RectF;
 import android.os.Bundle;
-import androidx.annotation.FloatRange;
-import androidx.annotation.IntRange;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.Size;
-import androidx.annotation.UiThread;
 import android.text.TextUtils;
 import android.view.View;
 
@@ -43,6 +37,13 @@ import com.mapbox.mapboxsdk.style.expressions.Expression;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import androidx.annotation.FloatRange;
+import androidx.annotation.IntRange;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.Size;
+import androidx.annotation.UiThread;
 
 /**
  * The general class to interact with in the Android Mapbox SDK. It exposes the entry point for all
@@ -135,14 +136,18 @@ public final class MapboxMap {
    * Called when the hosting Activity/Fragment onStart() method is called.
    */
   void onStart() {
-    locationComponent.onStart();
+    if (locationComponent != null) {
+      locationComponent.onStart();
+    }
   }
 
   /**
    * Called when the hosting Activity/Fragment onStop() method is called.
    */
   void onStop() {
-    locationComponent.onStop();
+    if (locationComponent != null) {
+      locationComponent.onStop();
+    }
   }
 
   /**
@@ -179,7 +184,9 @@ public final class MapboxMap {
    * Called when the hosting Activity/Fragment onDestroy()/onDestroyView() method is called.
    */
   void onDestroy() {
-    locationComponent.onDestroy();
+    if (locationComponent != null) {
+      locationComponent.onDestroy();
+    }
     if (style != null) {
       style.clear();
     }
@@ -921,7 +928,9 @@ public final class MapboxMap {
    */
   public void setStyle(Style.Builder builder, final Style.OnStyleLoaded callback) {
     styleLoadedCallback = callback;
-    locationComponent.onStartLoadingMap();
+    if (locationComponent != null) {
+      locationComponent.onStartLoadingMap();
+    }
     if (style != null) {
       style.clear();
     }
@@ -944,7 +953,9 @@ public final class MapboxMap {
 
     if (style != null) {
       style.onDidFinishLoadingStyle();
-      locationComponent.onFinishLoadingStyle();
+      if (locationComponent != null) {
+        locationComponent.onFinishLoadingStyle();
+      }
 
       // notify the listener provided with the style setter
       if (styleLoadedCallback != null) {

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
@@ -7,14 +7,6 @@ import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Parcel;
 import android.os.Parcelable;
-
-import androidx.annotation.ColorInt;
-import androidx.annotation.IntRange;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
-import androidx.core.content.res.ResourcesCompat;
-
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.Gravity;
@@ -26,6 +18,13 @@ import com.mapbox.mapboxsdk.utils.BitmapUtils;
 import com.mapbox.mapboxsdk.utils.FontUtils;
 
 import java.util.Arrays;
+
+import androidx.annotation.ColorInt;
+import androidx.annotation.IntRange;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+import androidx.core.content.res.ResourcesCompat;
 
 /**
  * Defines configuration MapboxMapMapOptions for a MapboxMap. These options can be used when adding a
@@ -74,6 +73,8 @@ public class MapboxMapOptions implements Parcelable {
   private boolean zoomGesturesEnabled = true;
   private boolean doubleTapGesturesEnabled = true;
   private boolean quickZoomGesturesEnabled = true;
+
+  private boolean locationComponentOptedIn = true;
 
   private boolean prefetchesTiles = true;
   private int prefetchZoomDelta = 4;
@@ -793,6 +794,18 @@ public class MapboxMapOptions implements Parcelable {
   }
 
   /**
+   * Opts LocationComponent in or out
+   *
+   * @param optedIn True is LocationComponent is opted in
+   * @return This
+   */
+  @NonNull
+  public MapboxMapOptions locationComponentOptedIn(boolean optedIn) {
+    locationComponentOptedIn = optedIn;
+    return this;
+  }
+
+  /**
    * Check whether tile pre-fetching is enabled.
    *
    * @return true if enabled
@@ -1125,6 +1138,15 @@ public class MapboxMapOptions implements Parcelable {
   @Nullable
   public String getLocalIdeographFontFamily() {
     return localIdeographFontFamilyEnabled ? localIdeographFontFamily : null;
+  }
+
+  /**
+   * Get whether the location component is opted in.
+   *
+   * @return True indicates location component is opted in
+   */
+  public boolean getLocationComponentOptedIn() {
+    return locationComponentOptedIn;
   }
 
   /**


### PR DESCRIPTION
On the low-spec custom hardware where every tiny bit counts in resources, we have use-cases when standard location component is never used as it does not fit the requirements.

This PR introduces the following:
- In use-cases when LocationComponent is never used, provide opt-out option
- Do not inject LocationComponent when opted out