### PR TITLE
Add pr template for drafting changelogs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,10 @@
-`<changelog>Add suggested changelog entry for this PR here.</changelog>`
+`<changelog>Replace text with suggested changelog entry for this PR.</changelog>`
 
 <!-- Examples: -->
-<!-- <changelog>Enabled reusing objects with `Projection.getVisibleCoordinateBounds`.</changelog> -->
-<!-- <changelog>Added an option to set the minimum and maximum pitch of a `Map`.-->
-<!-- <changelog>Introduced `in` expression for testing whether an item exists in an array or a substring exists in a string.</changelog>
-<!-- <changelog>Significantly improved offline pack download performance by marking resources as used in batches.</changelog>
-<!-- <changelog>Fixed a bug where non-overlapping symbols would be sorted incorrectly with `symbol-sort-key`.</changelog> -->
+<!-- `<changelog>Enabled reusing objects with `Projection.getVisibleCoordinateBounds`.</changelog>` -->
+<!-- `<changelog>Added an option to set the minimum and maximum pitch of a `Map`.</changelog>`-->
+<!-- `<changelog>Introduced `in` expression for testing whether an item exists in an array or a substring exists in a string.</changelog>`
+<!-- `<changelog>Significantly improved offline pack download performance by marking resources as used in batches.</changelog>`
+<!-- `<changelog>Fixed a bug where non-overlapping symbols would be sorted incorrectly with `symbol-sort-key`.</changelog>` -->
 
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,6 @@
 <!-- `<changelog>Added an option to set the minimum and maximum pitch of a `Map`.</changelog>`-->
 <!-- `<changelog>Introduced `in` expression for testing whether an item exists in an array or a substring exists in a string.</changelog>`
 <!-- `<changelog>Significantly improved offline pack download performance by marking resources as used in batches.</changelog>`
-<!-- `<changelog>Fixed a bug where non-overlapping symbols would be sorted incorrectly with `symbolSortKey`.</changelog>` -->
+<!-- `<changelog>Fixed a bug where non-overlapping symbols would be sorted incorrectly with `SymbolLayer.symbolSortKey`.</changelog>` -->
 
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,6 @@
 <!-- `<changelog>Added an option to set the minimum and maximum pitch of a `Map`.</changelog>`-->
 <!-- `<changelog>Introduced `in` expression for testing whether an item exists in an array or a substring exists in a string.</changelog>`
 <!-- `<changelog>Significantly improved offline pack download performance by marking resources as used in batches.</changelog>`
-<!-- `<changelog>Fixed a bug where non-overlapping symbols would be sorted incorrectly with `symbol-sort-key`.</changelog>` -->
+<!-- `<changelog>Fixed a bug where non-overlapping symbols would be sorted incorrectly with `symbolSortKey`.</changelog>` -->
 
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+`<changelog>Add suggested changelog entry for this PR here.</changelog>`
+
+<!-- Examples: -->
+<!-- <changelog>Enabled reusing objects with `Projection.getVisibleCoordinateBounds`.</changelog> -->
+<!-- <changelog>Added an option to set the minimum and maximum pitch of a `Map`.-->
+<!-- <changelog>Introduced `in` expression for testing whether an item exists in an array or a substring exists in a string.</changelog>
+<!-- <changelog>Significantly improved offline pack download performance by marking resources as used in batches.</changelog>
+<!-- <changelog>Fixed a bug where non-overlapping symbols would be sorted incorrectly with `symbol-sort-key`.</changelog> -->
+
+


### PR DESCRIPTION
This follows the convention set forth by GL JS ([example at the bottom of this PR](https://github.com/mapbox/mapbox-gl-js/pull/9349)) which makes it compatible with [github-release-tools](https://github.com/mapbox/github-release-tools)' changelog-draft script if we set it up in the future.

cc/ @mapbox/maps-android 