### PR TITLE
eglCreateWindowSurface() can only be called with an instance of Surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This beta release includes a feature with a known issue: the `within` expression
  - Fixed issues that would cause an offline region to stop downloading before completion. ([#16230](https://github.com/mapbox/mapbox-gl-native/pull/16230), [#16240](https://github.com/mapbox/mapbox-gl-native/pull/16240))
  - Fixed an issue where a `LineDasharray` value of `[1, 0]` resulted in hairline gaps. ([#16202](https://github.com/mapbox/mapbox-gl-native/pull/16202))
  - Fixed Proguard configuration to prevent obfuscation of telemetry event classes. ([#195](https://github.com/mapbox/mapbox-gl-native-android/pull/195))
+ - Fixed a crash that might occur during EGL window surface creation. ([#278](https://github.com/mapbox/mapbox-gl-native-android/pull/278))
 
 ### Other changes
  - Updated mapbox-events-android to v4.7.3. ([#201](https://github.com/mapbox/mapbox-gl-native-android/pull/201))

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/textureview/TextureViewRenderThread.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/textureview/TextureViewRenderThread.java
@@ -1,9 +1,11 @@
 package com.mapbox.mapboxsdk.maps.renderer.textureview;
 
 import android.graphics.SurfaceTexture;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
+
 import android.view.TextureView;
 
 import com.mapbox.mapboxsdk.log.Logger;
@@ -390,7 +392,7 @@ class TextureViewRenderThread extends Thread implements TextureView.SurfaceTextu
 
       // Create an EGL surface we can render into.
       TextureView view = textureViewWeakRef.get();
-      if (view != null) {
+      if (view != null && view.getSurfaceTexture() != null) {
         int[] surfaceAttribs = {EGL10.EGL_NONE};
         eglSurface = egl.eglCreateWindowSurface(eglDisplay, eglConfig, view.getSurfaceTexture(), surfaceAttribs);
       } else {


### PR DESCRIPTION
Fixes a crash: "eglCreateWindowSurface() can only be called with an instance of Surface, SurfaceView, SurfaceHolder or SurfaceTexture at the moment"

`<changelog>Fixed a crash that might occur during EGL window surface creation.</changelog>`

