### PR TITLE
High contrast accessibility mode fix

### DIFF
--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/text/LocalGlyphRasterizer.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/text/LocalGlyphRasterizer.java
@@ -4,7 +4,6 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Bitmap;
-import android.graphics.PorterDuff;
 import android.graphics.Typeface;
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
@@ -52,7 +51,7 @@ public class LocalGlyphRasterizer {
   @WorkerThread
   protected Bitmap drawGlyphBitmap(String fontFamily, boolean bold, char glyphID) {
     paint.setTypeface(Typeface.create(fontFamily, bold ? Typeface.BOLD : Typeface.NORMAL));
-    canvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
+    canvas.drawColor(Color.WHITE);
     canvas.drawText(String.valueOf(glyphID), 0, 20, paint);
     return bitmap;
   }


### PR DESCRIPTION
closes https://github.com/mapbox/mapbox-gl-native-android/issues/31

`<changelog>Fixed a bug that wrongly generated glyphs when high contrast accessibility mode was active by using RGB values instead of alpha channel. /changelog>`


![image](https://user-images.githubusercontent.com/2151639/77329009-a8b2f100-6d1d-11ea-8242-74035d9968cd.png)
