### PR TITLE
Add getLayer and getSource snapshotter methods

### DIFF
--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/snapshotter/MapSnapshotter.java
@@ -64,6 +64,8 @@ public class MapSnapshotter {
   private SnapshotReadyCallback callback;
   @Nullable
   private ErrorHandler errorHandler;
+  @Nullable
+  private Observer observer;
 
   /**
    * Get notified on snapshot completion.
@@ -95,6 +97,20 @@ public class MapSnapshotter {
      * @param error the error message
      */
     void onError(String error);
+  }
+
+  /**
+   * Can be used to get notified on snapshotter style loading
+   * completion.
+   *
+   * @see MapSnapshotter#setObserver(Observer)
+   */
+  public interface Observer {
+
+    /**
+     * Called when snapshotter finishes loading it's style.
+     */
+    void onDidFinishLoadingStyle();
   }
 
   /**
@@ -512,6 +528,16 @@ public class MapSnapshotter {
   }
 
   /**
+   * Sets observer for a snapshotter
+   *
+   * @param observer an Observer object
+   */
+  public void setObserver(@Nullable Observer observer) {
+    checkThread();
+    this.observer = observer;
+  }
+
+  /**
    * Draw an overlay on the map snapshot.
    *
    * @param mapSnapshot the map snapshot to draw the overlay on
@@ -736,6 +762,34 @@ public class MapSnapshotter {
         }
       }
     }
+
+    if (observer != null) {
+      observer.onDidFinishLoadingStyle();
+    }
+  }
+
+  /**
+   * Returns Layer of a style that is used by a snapshotter
+   *
+   * @param layerId the id of a Layer
+   * @return the Layer object if Layer with layerId exists, null otherwise
+   */
+  @Nullable
+  public Layer getLayer(@NonNull String layerId) {
+    checkThread();
+    return fullyLoaded ? nativeGetLayer(layerId) : null;
+  }
+
+  /**
+   * Returns Source of a style that is used by a snapshotter
+   *
+   * @param sourceId the id of a Source
+   * @return the Source object if a Source with sourceId exists, null otherwise
+   */
+  @Nullable
+  public Source getSource(@NonNull String sourceId) {
+    checkThread();
+    return fullyLoaded ? nativeGetSource(sourceId) : null;
   }
 
   /**
@@ -782,6 +836,14 @@ public class MapSnapshotter {
 
   @Keep
   private native void nativeAddImages(Image[] images);
+
+  @NonNull
+  @Keep
+  private native Layer nativeGetLayer(String layerId);
+
+  @NonNull
+  @Keep
+  private native Source nativeGetSource(String sourceId);
 
   @Override
   @Keep

--- a/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
+++ b/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
@@ -397,6 +397,17 @@
                 android:value=".activity.FeatureOverviewActivity" />
         </activity>
         <activity
+            android:name=".activity.turf.MapSnapshotterWithinExpression"
+            android:description="@string/description_snapshot_within"
+            android:label="@string/activity_snapshot_within">
+            <meta-data
+                android:name="@string/category"
+                android:value="@string/category_imagegenerator" />
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".activity.FeatureOverviewActivity" />
+        </activity>
+        <activity
             android:name=".activity.maplayout.DoubleMapActivity"
             android:description="@string/description_doublemap"
             android:label="@string/activity_double_map">

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/turf/MapSnapshotterWithinExpression.kt
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/turf/MapSnapshotterWithinExpression.kt
@@ -1,0 +1,274 @@
+package com.mapbox.mapboxsdk.testapp.activity.turf
+
+import android.graphics.Color
+import android.os.Bundle
+import android.os.PersistableBundle
+import androidx.appcompat.app.AppCompatActivity
+import com.mapbox.geojson.*
+import com.mapbox.mapboxsdk.camera.CameraPosition
+import com.mapbox.mapboxsdk.camera.CameraUpdateFactory
+import com.mapbox.mapboxsdk.geometry.LatLng
+import com.mapbox.mapboxsdk.maps.MapView
+import com.mapbox.mapboxsdk.maps.MapboxMap
+import com.mapbox.mapboxsdk.maps.Style
+import com.mapbox.mapboxsdk.snapshotter.MapSnapshotter
+import com.mapbox.mapboxsdk.style.expressions.Expression.within
+import com.mapbox.mapboxsdk.style.layers.CircleLayer
+import com.mapbox.mapboxsdk.style.layers.FillLayer
+import com.mapbox.mapboxsdk.style.layers.LineLayer
+import com.mapbox.mapboxsdk.style.layers.Property.NONE
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory.*
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer
+import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions
+import com.mapbox.mapboxsdk.style.sources.GeoJsonSource
+import com.mapbox.mapboxsdk.testapp.R
+import kotlinx.android.synthetic.main.activity_physical_circle.mapView
+import kotlinx.android.synthetic.main.activity_snapshot.*
+
+/**
+ * An Activity that showcases the use of MapSnapshotter with 'within' expression
+ */
+class MapSnapshotterWithinExpression : AppCompatActivity() {
+
+  private lateinit var mapboxMap: MapboxMap
+  private lateinit var snapshotter: MapSnapshotter
+  private var snapshotInProgress = false
+
+  private val cameraListener = object : MapView.OnCameraDidChangeListener {
+    override fun onCameraDidChange(animated: Boolean) {
+      if (!snapshotInProgress) {
+        snapshotInProgress = true
+        snapshotter.setCameraPosition(mapboxMap.cameraPosition)
+        snapshotter.start {
+          imageView.setImageBitmap(it.bitmap)
+          snapshotInProgress = false
+        }
+      }
+    }
+  }
+
+  private val snapshotterObserver = object : MapSnapshotter.Observer {
+    override fun onDidFinishLoadingStyle() {
+      // Show only POI labels inside geometry using within expression
+      (snapshotter.getLayer("poi-label") as SymbolLayer).setFilter(
+        within(
+          bufferLineStringGeometry()
+        )
+      )
+      // Hide other types of labels to highlight POI labels
+      (snapshotter.getLayer("road-label") as SymbolLayer).setProperties(visibility(NONE))
+      (snapshotter.getLayer("transit-label") as SymbolLayer).setProperties(visibility(NONE))
+      (snapshotter.getLayer("road-number-shield") as SymbolLayer).setProperties(visibility(NONE))
+    }
+  }
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContentView(R.layout.activity_mapsnapshotter_within_expression)
+
+    mapView.onCreate(savedInstanceState)
+    mapView.getMapAsync { map ->
+      mapboxMap = map
+
+      // Setup camera position above Georgetown
+      mapboxMap.cameraPosition = CameraPosition.Builder()
+        .target(LatLng(38.90628988399711, -77.06574689337494))
+        .zoom(15.5)
+        .build()
+
+      // Wait for the map to become idle before manipulating the style and camera of the map
+      mapView.addOnDidBecomeIdleListener(object : MapView.OnDidBecomeIdleListener {
+        override fun onDidBecomeIdle() {
+          mapboxMap.easeCamera(
+            CameraUpdateFactory.newCameraPosition(
+              CameraPosition.Builder()
+                .zoom(16.0)
+                .target(LatLng(38.905156245642814, -77.06535338052844))
+                .bearing(80.68015859462369)
+                .tilt(55.0)
+                .build()
+            ), 1000
+          )
+          mapView.removeOnDidBecomeIdleListener(this)
+        }
+      })
+      // Load mapbox streets and add lines and circles
+      setupStyle()
+    }
+  }
+
+  private fun setupStyle() {
+    // Assume the route is represented by an array of coordinates.
+    val coordinates = listOf<Point>(
+      Point.fromLngLat(
+        -77.06866264343262,
+        38.90506061276737
+      ),
+      Point.fromLngLat(
+        -77.06283688545227,
+        38.905194197410545
+      ),
+      Point.fromLngLat(
+        -77.06285834312439,
+        38.906429843444094
+      ),
+      Point.fromLngLat(
+        -77.0630407333374,
+        38.90680554236621
+      )
+    )
+
+    // Setup style with additional layers,
+    // using Style.MAPBOX_STREETS as a base style
+    mapboxMap.setStyle(
+      Style.Builder()
+        .fromUri(Style.MAPBOX_STREETS)
+    ) {
+      mapView.addOnCameraDidChangeListener(cameraListener)
+    }
+
+    val options = MapSnapshotter.Options(imageView.measuredWidth / 2, imageView.measuredHeight / 2)
+      .withCameraPosition(mapboxMap.cameraPosition)
+      .withPixelRatio(2.0f)
+      .withStyleBuilder(Style.Builder()
+        .fromUri(Style.MAPBOX_STREETS)
+        .withSources(
+          GeoJsonSource(
+            POINT_ID, LineString.fromLngLats(coordinates)
+          ),
+          GeoJsonSource(
+            FILL_ID,
+            FeatureCollection.fromFeature(Feature.fromGeometry(bufferLineStringGeometry())),
+            GeoJsonOptions().withBuffer(0).withTolerance(0.0f)
+          )
+        )
+        .withLayerBelow(
+          LineLayer(LINE_ID, POINT_ID)
+            .withProperties(lineWidth(7.5f), lineColor(Color.LTGRAY)),
+          "poi-label"
+        )
+        .withLayerBelow(
+          CircleLayer(POINT_ID, POINT_ID)
+            .withProperties(
+              circleRadius(7.5f),
+              circleColor(Color.DKGRAY),
+              circleOpacity(0.75f)
+            ), "poi-label"
+        ).withLayerBelow(
+          FillLayer(FILL_ID, FILL_ID)
+            .withProperties(
+              fillOpacity(0.12f),
+              fillColor(Color.YELLOW)
+            ), LINE_ID
+        ))
+    snapshotter = MapSnapshotter(this, options)
+    snapshotter.setObserver(snapshotterObserver)
+  }
+
+  override fun onStart() {
+    super.onStart()
+    mapView.onStart()
+  }
+
+  override fun onResume() {
+    super.onResume()
+    mapView.onResume()
+  }
+
+  override fun onPause() {
+    super.onPause()
+    mapView.onPause()
+  }
+
+  override fun onStop() {
+    super.onStop()
+    mapView.onStop()
+  }
+
+  override fun onLowMemory() {
+    super.onLowMemory()
+    mapView.onLowMemory()
+  }
+
+  override fun onDestroy() {
+    super.onDestroy()
+    mapView.onDestroy()
+  }
+
+  override fun onSaveInstanceState(outState: Bundle?, outPersistentState: PersistableBundle?) {
+    super.onSaveInstanceState(outState, outPersistentState)
+    outState?.let {
+      mapView.onSaveInstanceState(it)
+    }
+  }
+
+  private fun bufferLineStringGeometry(): Polygon {
+    // TODO replace static data by Turf#Buffer: mapbox-java/issues/987
+    return FeatureCollection.fromJson(
+      """
+    {
+      "type": "FeatureCollection",
+      "features": [
+        {
+          "type": "Feature",
+          "properties": {},
+          "geometry": {
+            "type": "Polygon",
+            "coordinates": [
+              [
+                [
+                  -77.06867337226866,
+                  38.90467655551809
+                ],
+                [
+                  -77.06233263015747,
+                  38.90479344272695
+                ],
+                [
+                  -77.06234335899353,
+                  38.906463238984344
+                ],
+                [
+                  -77.06290125846863,
+                  38.907206285691615
+                ],
+                [
+                  -77.06364154815674,
+                  38.90684728656818
+                ],
+                [
+                  -77.06326603889465,
+                  38.90637140121084
+                ],
+                [
+                  -77.06321239471436,
+                  38.905561553883246
+                ],
+                [
+                  -77.0691454410553,
+                  38.905436318935635
+                ],
+                [
+                  -77.06912398338318,
+                  38.90466820642439
+                ],
+                [
+                  -77.06867337226866,
+                  38.90467655551809
+                ]
+              ]
+            ]
+          }
+        }
+      ]
+    }
+  """.trimIndent()
+    ).features()!![0].geometry() as Polygon
+  }
+
+  companion object {
+    const val POINT_ID = "point"
+    const val FILL_ID = "fill"
+    const val LINE_ID = "line"
+  }
+}

--- a/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_mapsnapshotter_within_expression.xml
+++ b/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_mapsnapshotter_within_expression.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".activity.style.DraggableMarkerActivity">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <com.mapbox.mapboxsdk.maps.MapView
+            android:id="@+id/mapView"
+            android:layout_width="match_parent"
+            android:layout_height="313dp">
+
+        </com.mapbox.mapboxsdk.maps.MapView>
+
+        <ImageView
+            android:id="@+id/imageView"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:background="@color/primary"
+            android:contentDescription="@null" />
+
+    </LinearLayout>
+
+</RelativeLayout>

--- a/MapboxGLAndroidSDKTestApp/src/main/res/values/descriptions.xml
+++ b/MapboxGLAndroidSDKTestApp/src/main/res/values/descriptions.xml
@@ -28,6 +28,7 @@
     <string name="description_polygon">Add a polygon to a map</string>
     <string name="description_scroll_by">Scroll with pixels in x,y direction</string>
     <string name="description_snapshot">Example to make a snapshot of the map</string>
+    <string name="description_snapshot_within">Example of snapshotter with within expression</string>
     <string name="description_doublemap">2 maps in a view hierarchy</string>
     <string name="description_dynamic_info_window_adapter">Learn how to create a dynamic custom InfoWindow</string>
     <string name="description_viewpager">Use SupportMapFragments in a ViewPager</string>

--- a/MapboxGLAndroidSDKTestApp/src/main/res/values/titles.xml
+++ b/MapboxGLAndroidSDKTestApp/src/main/res/values/titles.xml
@@ -21,6 +21,7 @@
     <string name="activity_scroll_by">Scroll By Method</string>
     <string name="activity_double_map">Double Map Activity</string>
     <string name="activity_snapshot">Snapshot Activity</string>
+    <string name="activity_snapshot_within">Snapshot with within expression</string>
     <string name="activity_custom_layer">Custom Layer</string>
     <string name="activity_map_padding">Map Padding</string>
     <string name="activity_debug_mode">Debug Mode</string>


### PR DESCRIPTION
`<changelog>Add getLayer, getSource and Observer interface for a MapSnapshotter, so that the developer can modify snapshotter's layer and/or source object's properties.</changelog>`

<!-- Examples: -->
<!-- `<changelog>Enabled reusing objects with `Projection.getVisibleCoordinateBounds`.</changelog>` -->
<!-- `<changelog>Added an option to set the minimum and maximum pitch of a `Map`.</changelog>`-->
<!-- `<changelog>Introduced `in` expression for testing whether an item exists in an array or a substring exists in a string.</changelog>`
<!-- `<changelog>Significantly improved offline pack download performance by marking resources as used in batches.</changelog>`
<!-- `<changelog>Fixed a bug where non-overlapping symbols would be sorted incorrectly with `SymbolLayer.symbolSortKey`.</changelog>` -->


