### PR TITLE
Add bindings for setting max parent tile overscale factor

### DIFF
--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/Source.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/Source.java
@@ -93,6 +93,29 @@ public abstract class Source {
   }
 
   /**
+   * When a set of tiles for a current zoom level is being rendered and some of the
+   * ideal tiles that cover the screen are not yet loaded, parent tile could be
+   * used instead. This might introduce unwanted rendering side-effects, especially
+   * for raster tiles that are overscaled multiple times. This method sets the maximum
+   * limit for how much a parent tile can be overscaled.
+   *
+   * @param maxOverscaleFactor maximum overscale factor
+   */
+  public void setMaxOverscaleFactorForParentTiles(@Nullable Integer maxOverscaleFactor) {
+    nativeSetMaxOverscaleFactorForParentTiles(maxOverscaleFactor);
+  }
+
+  /**
+   * Retrieve current maximum overscale factor for parent tiles.
+   *
+   * @return current maximum overscale factor or null if not set.
+   */
+  @Nullable
+  public Integer getMaxOverscaleFactorForParentTiles() {
+    return nativeGetMaxOverscaleFactorForParentTiles();
+  }
+
+  /**
    * Internal use
    *
    * @return the native peer pointer


### PR DESCRIPTION
`<changelog>Add a new method that sets a limit for how much parent tile can be overscaled.</changelog>`

<!-- Examples: -->
<!-- `<changelog>Enabled reusing objects with `Projection.getVisibleCoordinateBounds`.</changelog>` -->
<!-- `<changelog>Added an option to set the minimum and maximum pitch of a `Map`.</changelog>`-->
<!-- `<changelog>Introduced `in` expression for testing whether an item exists in an array or a substring exists in a string.</changelog>`
<!-- `<changelog>Significantly improved offline pack download performance by marking resources as used in batches.</changelog>`
<!-- `<changelog>Fixed a bug where non-overlapping symbols would be sorted incorrectly with `SymbolLayer.symbolSortKey`.</changelog>` -->


