### PR TITLE
Fix Proguard telemetry events rule

### DIFF
--- a/MapboxGLAndroidSDK/proguard-rules.pro
+++ b/MapboxGLAndroidSDK/proguard-rules.pro
@@ -28,7 +28,7 @@
 -dontwarn com.google.auto.value.**
 
 # config for telemetry events
--keep class com.mapbox.mapboxsdk.module.telemetry.**
+-keep class com.mapbox.mapboxsdk.module.telemetry.** { *; }
 
 # config for additional notes
 -dontnote org.robolectric.Robolectric


### PR DESCRIPTION
`<changelog>Fix Proguard telemetry events rule</changelog>`

<!-- Examples: -->
<!-- `<changelog>Enabled reusing objects with `Projection.getVisibleCoordinateBounds`.</changelog>` -->
<!-- `<changelog>Added an option to set the minimum and maximum pitch of a `Map`.</changelog>`-->
<!-- `<changelog>Introduced `in` expression for testing whether an item exists in an array or a substring exists in a string.</changelog>`
<!-- `<changelog>Significantly improved offline pack download performance by marking resources as used in batches.</changelog>`
<!-- `<changelog>Fixed a bug where non-overlapping symbols would be sorted incorrectly with `SymbolLayer.symbolSortKey`.</changelog>` -->

Regression from https://github.com/mapbox/mapbox-gl-native-android/pull/195

Testing https://github.com/mapbox/mapbox-navigation-android/pull/2643 we found out that we were sending some Maps minified events e.g. 👀 

```json
{"e":"Android - 6.0.1","f":"Nexus 5","g":"e8cfa25c-2284-46db-a25d-8bed98dea8da","h":"Ting","i":"HSPA","j":"Portrait","k":3,"l":1,"m":100,"n":true,"o":true}
```

This PR adds `{ *; }` to https://github.com/mapbox/mapbox-gl-native-android/blob/dceba083117f32721bd36dc31eec7f9b5aeebce1/MapboxGLAndroidSDK/proguard-rules.pro#L31 Proguard rule ensuring that all members inside classes are also not obfuscated

`mapping.txt`

_Before_

```
com.mapbox.mapboxsdk.module.telemetry.MapLoadEvent -> com.mapbox.mapboxsdk.module.telemetry.MapLoadEvent:
    java.lang.String userId -> g
    float accessibilityFontScale -> l
    java.lang.String model -> f
    float resolution -> k
    boolean pluggedIn -> n
    java.lang.String cellularNetworkType -> i
    boolean wifi -> o
    java.lang.String carrier -> h
    int batteryLevel -> m
    java.lang.String orientation -> j
    java.lang.String operatingSystem -> e
    29:39:void <init>(java.lang.String,com.mapbox.mapboxsdk.module.telemetry.PhoneState) -> <init>
    43:43:java.lang.String getEventName() -> a
    100:104:boolean equals(java.lang.Object) -> equals
    145:158:int hashCode() -> hashCode
    163:163:java.lang.String toString() -> toString
com.mapbox.mapboxsdk.module.telemetry.OfflineDownloadEndEvent -> com.mapbox.mapboxsdk.module.telemetry.OfflineDownloadEndEvent:
    java.lang.Double minZoom -> e
    java.lang.String shapeForOfflineRegion -> g
    long sizeOfResourcesCompleted -> j
    java.lang.String state -> i
    java.lang.String styleURL -> h
    long numberOfTilesCompleted -> k
    java.lang.Double maxZoom -> f
    36:36:java.lang.String getEventName() -> a
    12:12:int describeContents() -> describeContents
    85:89:boolean equals(java.lang.Object) -> equals
    118:125:int hashCode() -> hashCode
    130:130:java.lang.String toString() -> toString
    12:12:void writeToParcel(android.os.Parcel,int) -> writeToParcel
com.mapbox.mapboxsdk.module.telemetry.OfflineDownloadStartEvent -> com.mapbox.mapboxsdk.module.telemetry.OfflineDownloadStartEvent:
    java.lang.Double minZoom -> e
    java.lang.String shapeForOfflineRegion -> g
    java.lang.String styleURL -> h
    java.lang.Double maxZoom -> f
    24:28:void <init>(com.mapbox.mapboxsdk.module.telemetry.PhoneState,java.lang.String,java.lang.Double,java.lang.Double) -> <init>
    32:32:java.lang.String getEventName() -> a
    52:53:void setStyleURL(java.lang.String) -> a
    11:11:int describeContents() -> describeContents
    57:61:boolean equals(java.lang.Object) -> equals
    81:85:int hashCode() -> hashCode
    90:90:java.lang.String toString() -> toString
    11:11:void writeToParcel(android.os.Parcel,int) -> writeToParcel
com.mapbox.mapboxsdk.module.telemetry.PerformanceEvent -> com.mapbox.mapboxsdk.module.telemetry.PerformanceEvent:
    java.util.List attributes -> f
    com.google.gson.JsonObject metadata -> h
    java.util.List counters -> g
    java.lang.String sessionId -> e
    85:85:java.lang.String getEventName() -> a
    106:110:boolean equals(java.lang.Object) -> equals
    129:133:int hashCode() -> hashCode
    138:138:java.lang.String toString() -> toString
com.mapbox.mapboxsdk.module.telemetry.PerformanceEvent$PerformanceAttribute -> com.mapbox.mapboxsdk.module.telemetry.PerformanceEvent$PerformanceAttribute:
    java.lang.Object value -> b
    java.lang.String name -> a
    157:161:boolean equals(java.lang.Object) -> equals
    174:176:int hashCode() -> hashCode
com.mapbox.mapboxsdk.module.telemetry.PhoneState -> com.mapbox.mapboxsdk.module.telemetry.PhoneState:
    float resolution -> i
    float accessibilityFontScale -> h
    boolean pluggedIn -> f
    java.lang.String created -> a
    boolean wifi -> g
    int batteryLevel -> e
    java.lang.String cellularNetworkType -> b
    com.mapbox.mapboxsdk.module.telemetry.PhoneState$Orientation orientation -> c
    java.lang.String carrier -> d
    31:33:void <init>() -> <init>
    35:45:void <init>(android.content.Context) -> <init>
    67:75:boolean isConnectedToWifi(android.content.Context) -> a
    136:136:float getAccessibilityFontScale() -> a
    48:56:java.lang.String obtainCellularCarrier(android.content.Context) -> b
    88:88:int getBatteryLevel() -> b
    60:62:float obtainDisplayDensity(android.content.Context) -> c
    120:120:java.lang.String getCarrier() -> c
    104:104:java.lang.String getCellularNetworkType() -> d
    80:80:java.lang.String getCreated() -> e
    112:112:java.lang.String getOrientation() -> f
    144:144:float getResolution() -> g
    96:96:boolean isPluggedIn() -> h
    128:128:boolean isWifi() -> i
com.mapbox.mapboxsdk.module.telemetry.PhoneState$Orientation -> com.mapbox.mapboxsdk.module.telemetry.PhoneState$Orientation:
    com.mapbox.mapboxsdk.module.telemetry.PhoneState$Orientation ORIENTATION_PORTRAIT -> f
    com.mapbox.mapboxsdk.module.telemetry.PhoneState$Orientation ORIENTATION_LANDSCAPE -> g
    com.mapbox.mapboxsdk.module.telemetry.PhoneState$Orientation[] $VALUES -> h
    java.lang.String orientation -> e
    152:151:void <clinit>() -> <clinit>
    156:158:void <init>(java.lang.String,int,java.lang.String) -> <init>
    168:168:java.lang.String getOrientation() -> a
    161:164:com.mapbox.mapboxsdk.module.telemetry.PhoneState$Orientation getOrientation(int) -> b
    151:151:com.mapbox.mapboxsdk.module.telemetry.PhoneState$Orientation valueOf(java.lang.String) -> valueOf
    151:151:com.mapbox.mapboxsdk.module.telemetry.PhoneState$Orientation[] values() -> values
```

_After_

```
com.mapbox.mapboxsdk.module.telemetry.MapLoadEvent -> com.mapbox.mapboxsdk.module.telemetry.MapLoadEvent:
    29:39:void <init>(java.lang.String,com.mapbox.mapboxsdk.module.telemetry.PhoneState) -> <init>
    100:104:boolean equals(java.lang.Object) -> equals
    83:83:float getAccessibilityFontScale() -> getAccessibilityFontScale
    87:87:int getBatteryLevel() -> getBatteryLevel
    67:67:java.lang.String getCarrier() -> getCarrier
    71:71:java.lang.String getCellularNetworkType() -> getCellularNetworkType
    43:43:java.lang.String getEventName() -> getEventName
    59:59:java.lang.String getModel() -> getModel
    47:47:java.lang.String getOperatingSystem() -> getOperatingSystem
    75:75:java.lang.String getOrientation() -> getOrientation
    79:79:float getResolution() -> getResolution
    51:51:java.lang.String getSdkIdentifier() -> getSdkIdentifier
    55:55:java.lang.String getSdkVersion() -> getSdkVersion
    63:63:java.lang.String getUserId() -> getUserId
    145:158:int hashCode() -> hashCode
    91:91:boolean isPluggedIn() -> isPluggedIn
    95:95:boolean isWifi() -> isWifi
    163:163:java.lang.String toString() -> toString
com.mapbox.mapboxsdk.module.telemetry.OfflineDownloadEndEvent -> com.mapbox.mapboxsdk.module.telemetry.OfflineDownloadEndEvent:
    28:32:void <init>(com.mapbox.mapboxsdk.module.telemetry.PhoneState,java.lang.String,java.lang.Double,java.lang.Double) -> <init>
    12:12:int describeContents() -> describeContents
    85:89:boolean equals(java.lang.Object) -> equals
    36:36:java.lang.String getEventName() -> getEventName
    44:44:java.lang.Double getMaxZoom() -> getMaxZoom
    40:40:java.lang.Double getMinZoom() -> getMinZoom
    68:68:long getNumberOfTilesCompleted() -> getNumberOfTilesCompleted
    48:48:java.lang.String getShapeForOfflineRegion() -> getShapeForOfflineRegion
    60:60:long getSizeOfResourcesCompleted() -> getSizeOfResourcesCompleted
    76:76:java.lang.String getState() -> getState
    52:52:java.lang.String getStyleURL() -> getStyleURL
    118:125:int hashCode() -> hashCode
    72:73:void setNumberOfTilesCompleted(long) -> setNumberOfTilesCompleted
    64:65:void setSizeOfResourcesCompleted(long) -> setSizeOfResourcesCompleted
    80:81:void setState(int) -> setState
    56:57:void setStyleURL(java.lang.String) -> setStyleURL
    130:130:java.lang.String toString() -> toString
    12:12:void writeToParcel(android.os.Parcel,int) -> writeToParcel
com.mapbox.mapboxsdk.module.telemetry.OfflineDownloadStartEvent -> com.mapbox.mapboxsdk.module.telemetry.OfflineDownloadStartEvent:
    24:28:void <init>(com.mapbox.mapboxsdk.module.telemetry.PhoneState,java.lang.String,java.lang.Double,java.lang.Double) -> <init>
    11:11:int describeContents() -> describeContents
    57:61:boolean equals(java.lang.Object) -> equals
    32:32:java.lang.String getEventName() -> getEventName
    40:40:java.lang.Double getMaxZoom() -> getMaxZoom
    36:36:java.lang.Double getMinZoom() -> getMinZoom
    44:44:java.lang.String getShapeForOfflineRegion() -> getShapeForOfflineRegion
    48:48:java.lang.String getStyleURL() -> getStyleURL
    81:85:int hashCode() -> hashCode
    52:53:void setStyleURL(java.lang.String) -> setStyleURL
    90:90:java.lang.String toString() -> toString
    11:11:void writeToParcel(android.os.Parcel,int) -> writeToParcel
com.mapbox.mapboxsdk.module.telemetry.PerformanceEvent -> com.mapbox.mapboxsdk.module.telemetry.PerformanceEvent:
    57:66:void <init>(com.mapbox.mapboxsdk.module.telemetry.PhoneState,java.lang.String,android.os.Bundle) -> <init>
    106:110:boolean equals(java.lang.Object) -> equals
    93:93:java.util.List getAttributes() -> getAttributes
    97:97:java.util.List getCounters() -> getCounters
    85:85:java.lang.String getEventName() -> getEventName
    101:101:com.google.gson.JsonObject getMetadata() -> getMetadata
    89:89:java.lang.String getSessionId() -> getSessionId
    129:133:int hashCode() -> hashCode
    69:70:java.util.ArrayList initList(java.lang.String,com.google.gson.reflect.TypeToken) -> initList
    76:79:com.google.gson.JsonObject initMetaData(java.lang.String) -> initMetaData
    138:138:java.lang.String toString() -> toString
com.mapbox.mapboxsdk.module.telemetry.PerformanceEvent$1 -> com.mapbox.mapboxsdk.module.telemetry.PerformanceEvent$1:
    60:60:void <init>(com.mapbox.mapboxsdk.module.telemetry.PerformanceEvent) -> <init>
com.mapbox.mapboxsdk.module.telemetry.PerformanceEvent$2 -> com.mapbox.mapboxsdk.module.telemetry.PerformanceEvent$2:
    63:63:void <init>(com.mapbox.mapboxsdk.module.telemetry.PerformanceEvent) -> <init>
com.mapbox.mapboxsdk.module.telemetry.PerformanceEvent$PerformanceAttribute -> com.mapbox.mapboxsdk.module.telemetry.PerformanceEvent$PerformanceAttribute:
    150:153:void <init>(java.lang.String,java.lang.Object) -> <init>
    157:161:boolean equals(java.lang.Object) -> equals
    174:176:int hashCode() -> hashCode
com.mapbox.mapboxsdk.module.telemetry.PhoneState -> com.mapbox.mapboxsdk.module.telemetry.PhoneState:
    31:33:void <init>() -> <init>
    35:45:void <init>(android.content.Context) -> <init>
    136:136:float getAccessibilityFontScale() -> getAccessibilityFontScale
    88:88:int getBatteryLevel() -> getBatteryLevel
    120:120:java.lang.String getCarrier() -> getCarrier
    104:104:java.lang.String getCellularNetworkType() -> getCellularNetworkType
    80:80:java.lang.String getCreated() -> getCreated
    112:112:java.lang.String getOrientation() -> getOrientation
    144:144:float getResolution() -> getResolution
    67:75:boolean isConnectedToWifi(android.content.Context) -> isConnectedToWifi
    96:96:boolean isPluggedIn() -> isPluggedIn
    128:128:boolean isWifi() -> isWifi
    48:56:java.lang.String obtainCellularCarrier(android.content.Context) -> obtainCellularCarrier
    60:62:float obtainDisplayDensity(android.content.Context) -> obtainDisplayDensity
    140:141:void setAccessibilityFontScale(float) -> setAccessibilityFontScale
    92:93:void setBatteryLevel(int) -> setBatteryLevel
    124:125:void setCarrier(java.lang.String) -> setCarrier
    108:109:void setCellularNetworkType(java.lang.String) -> setCellularNetworkType
    84:85:void setCreated(java.lang.String) -> setCreated
    116:117:void setOrientation(com.mapbox.mapboxsdk.module.telemetry.PhoneState$Orientation) -> setOrientation
    100:101:void setPluggedIn(boolean) -> setPluggedIn
    148:149:void setResolution(float) -> setResolution
    132:133:void setWifi(boolean) -> setWifi
com.mapbox.mapboxsdk.module.telemetry.PhoneState$Orientation -> com.mapbox.mapboxsdk.module.telemetry.PhoneState$Orientation:
    152:151:void <clinit>() -> <clinit>
    156:158:void <init>(java.lang.String,int,java.lang.String) -> <init>
    161:164:com.mapbox.mapboxsdk.module.telemetry.PhoneState$Orientation getOrientation(int) -> getOrientation
    168:168:java.lang.String getOrientation() -> getOrientation
    151:151:com.mapbox.mapboxsdk.module.telemetry.PhoneState$Orientation valueOf(java.lang.String) -> valueOf
    151:151:com.mapbox.mapboxsdk.module.telemetry.PhoneState$Orientation[] values() -> values
```

Tested before and after adding the rule explicitly in the Navigation SDK side.

As seen above properties are not obfuscated anymore. We've also confirmed that events are properly ingested.

cc @Chaoba @tobrun @harvsu @RingerJK 

