### PR TITLE
Make mapview unable to intercept scroll event 

### DIFF
--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/GLSurfaceRecyclerViewActivity.kt
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/GLSurfaceRecyclerViewActivity.kt
@@ -75,6 +75,7 @@ open class GLSurfaceRecyclerViewActivity : AppCompatActivity() {
       super.onViewAttachedToWindow(holder)
       if (holder is MapHolder) {
         val mapView = holder.mapView
+        mapView.isEnabled = false
         mapView.onStart()
         mapView.onResume()
       }


### PR DESCRIPTION

`<changelog>Make mapview unable to intercept scroll event in RecyclerView.</changelog>`

Resolves #225 