### PR TITLE
Add example of image in label

### DIFF
--- a/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
+++ b/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
@@ -1135,6 +1135,18 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".activity.FeatureOverviewActivity" />
         </activity>
+        <activity
+            android:name=".activity.style.ImageInLabelActivity"
+            android:description="@string/description_image_in_label"
+            android:exported="true"
+            android:label="@string/activity_image_in_label">
+            <meta-data
+                android:name="@string/category"
+                android:value="@string/category_style" />
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".activity.FeatureOverviewActivity" />
+        </activity>
         <!-- For Instrumentation tests -->
         <activity
             android:name=".activity.style.RuntimeStyleTimingTestActivity"

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/ImageInLabelActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/ImageInLabelActivity.java
@@ -1,0 +1,131 @@
+package com.mapbox.mapboxsdk.testapp.activity.style;
+
+import android.graphics.Bitmap;
+import android.graphics.Color;
+import android.os.Bundle;
+
+import com.mapbox.geojson.Feature;
+import com.mapbox.geojson.FeatureCollection;
+import com.mapbox.geojson.Point;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.mapboxsdk.style.expressions.Expression;
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
+import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
+import com.mapbox.mapboxsdk.testapp.R;
+import com.mapbox.mapboxsdk.utils.BitmapUtils;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+
+import static com.mapbox.mapboxsdk.style.expressions.Expression.FormatOption.formatFontScale;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.FormatOption.formatTextColor;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.FormatOption.formatTextFont;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.formatEntry;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.image;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.literal;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textAllowOverlap;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textField;
+
+/**
+ * Test image in label.
+ */
+public class ImageInLabelActivity extends AppCompatActivity implements OnMapReadyCallback {
+  private static final String ORIGINAL_SOURCE = "ORIGINAL_SOURCE";
+  private static final String ORIGINAL_LAYER = "ORIGINAL_LAYER";
+  private MapView mapView;
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_stretchable_image);
+    mapView = findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(this);
+  }
+
+  @Override
+  public void onMapReady(@NonNull MapboxMap mapboxMap) {
+    mapboxMap.setStyle(Style.MAPBOX_STREETS, style -> {
+      Bitmap us = BitmapUtils.getBitmapFromDrawable(getResources().getDrawable(R.drawable.ic_us));
+      Bitmap android = BitmapUtils.getBitmapFromDrawable(getResources().getDrawable(R.drawable.ic_android));
+
+      style.addImage("us", us);
+      style.addImage("android", android);
+
+      Point point = Point.fromLngLat(-10, 0);
+      Feature feature = Feature.fromGeometry(point);
+      FeatureCollection originalCollection = FeatureCollection.fromFeature(feature);
+      GeoJsonSource originalSource = new GeoJsonSource(ORIGINAL_SOURCE, originalCollection);
+      SymbolLayer originalLayer = new SymbolLayer(ORIGINAL_LAYER, ORIGINAL_SOURCE)
+        .withProperties(
+          textAllowOverlap(true),
+          textField(Expression
+            .format(
+              formatEntry(literal("Android: "),
+                formatFontScale(1.0),
+                formatTextColor(Color.BLUE),
+                formatTextFont(new String[] {"Ubuntu Medium", "Arial Unicode MS Regular"})),
+              formatEntry(image(literal("android"))),
+              formatEntry(literal("Us: "),
+                formatFontScale(1.5),
+                formatTextColor(Color.YELLOW)),
+              formatEntry(image(literal("us"))),
+              formatEntry(literal("suffix"),
+                formatFontScale(2.0),
+                formatTextColor(Color.CYAN))
+            )
+          )
+
+        );
+
+      style.addSource(originalSource);
+      style.addLayer(originalLayer);
+    });
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  public void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  @Override
+  public void onDestroy() {
+    super.onDestroy();
+    mapView.onDestroy();
+  }
+
+}

--- a/MapboxGLAndroidSDKTestApp/src/main/res/values/descriptions.xml
+++ b/MapboxGLAndroidSDKTestApp/src/main/res/values/descriptions.xml
@@ -21,6 +21,7 @@
     <string name="description_region">Download an offline region.</string>
     <string name="description_within">Usage of the within expression on a buffered geometry</string>
     <string name="description_stretchable_image">Usage of the stretchable image as a background for text.</string>
+    <string name="description_image_in_label">Usage of the image in label.</string>
     <string name="description_update_metadata">Update metadata example</string>
     <string name="description_offline_region_delete">Delete region example</string>
     <string name="description_change_resources_cache_path">Change resources cache path example</string>

--- a/MapboxGLAndroidSDKTestApp/src/main/res/values/titles.xml
+++ b/MapboxGLAndroidSDKTestApp/src/main/res/values/titles.xml
@@ -91,4 +91,5 @@
     <string name="activity_region">Download region</string>
     <string name="activity_within">Within expression</string>
     <string name="activity_stretchable_image">Stretchable Image</string>
+    <string name="activity_image_in_label">Image In Label</string>
 </resources>


### PR DESCRIPTION
This PR adds a test activity for image in label.
Fixes #315
cc: @chloekraw 

![image](https://user-images.githubusercontent.com/8577318/79436933-17752880-8004-11ea-9e16-fe1812dc316e.png)
