### PR TITLE
Fix some compass related issues

### DIFF
--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentCompassEngine.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentCompassEngine.java
@@ -69,16 +69,10 @@ class LocationComponentCompassEngine implements CompassEngine, SensorEventListen
     this.sensorManager = sensorManager;
     compassSensor = sensorManager.getDefaultSensor(Sensor.TYPE_ROTATION_VECTOR);
     if (compassSensor == null) {
-      if (isGyroscopeAvailable()) {
-        Logger.d(TAG, "Rotation vector sensor not supported on device, "
-                + "falling back to orientation.");
-        compassSensor = sensorManager.getDefaultSensor(Sensor.TYPE_ORIENTATION);
-      } else {
-        Logger.d(TAG, "Rotation vector sensor not supported on device, "
-                        + "falling back to accelerometer and magnetic field.");
-        gravitySensor = sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER);
-        magneticFieldSensor = sensorManager.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD);
-      }
+      Logger.d(TAG, "Rotation vector sensor not supported on device, "
+              + "falling back to accelerometer and magnetic field.");
+      gravitySensor = sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER);
+      magneticFieldSensor = sensorManager.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD);
     }
   }
 
@@ -122,8 +116,6 @@ class LocationComponentCompassEngine implements CompassEngine, SensorEventListen
     if (event.sensor.getType() == Sensor.TYPE_ROTATION_VECTOR) {
       rotationVectorValue = getRotationVectorFromSensorEvent(event);
       updateOrientation();
-    } else if (event.sensor.getType() == Sensor.TYPE_ORIENTATION) {
-      notifyCompassChangeListeners((event.values[0] + 360) % 360);
     } else if (event.sensor.getType() == Sensor.TYPE_ACCELEROMETER) {
       gravityValues = lowPassFilter(getRotationVectorFromSensorEvent(event), gravityValues);
       updateOrientation();
@@ -144,10 +136,6 @@ class LocationComponentCompassEngine implements CompassEngine, SensorEventListen
       }
       lastAccuracySensorStatus = accuracy;
     }
-  }
-
-  private boolean isGyroscopeAvailable() {
-    return sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE) != null;
   }
 
   @SuppressWarnings("SuspiciousNameCombination")

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentCompassEngine.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentCompassEngine.java
@@ -106,7 +106,9 @@ class LocationComponentCompassEngine implements CompassEngine, SensorEventListen
   public void onSensorChanged(@NonNull SensorEvent event) {
     if (lastAccuracySensorStatus == SensorManager.SENSOR_STATUS_UNRELIABLE) {
       Logger.d(TAG, "Compass sensor is unreliable, device calibration is needed.");
-      return;
+      // Update the heading, even if the sensor is unreliable.
+      // This makes it possible to use a different indicator for the unreliable case, instead of just changing the RenderMode to NORMAL.
+      //return;
     }
     if (event.sensor.getType() == Sensor.TYPE_ROTATION_VECTOR) {
       rotationVectorValue = getRotationVectorFromSensorEvent(event);

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentCompassEngine.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentCompassEngine.java
@@ -107,7 +107,8 @@ class LocationComponentCompassEngine implements CompassEngine, SensorEventListen
     if (lastAccuracySensorStatus == SensorManager.SENSOR_STATUS_UNRELIABLE) {
       Logger.d(TAG, "Compass sensor is unreliable, device calibration is needed.");
       // Update the heading, even if the sensor is unreliable.
-      // This makes it possible to use a different indicator for the unreliable case, instead of just changing the RenderMode to NORMAL.
+      // This makes it possible to use a different indicator for the unreliable case,
+      // instead of just changing the RenderMode to NORMAL.
       //return;
     }
     if (event.sensor.getType() == Sensor.TYPE_ROTATION_VECTOR) {

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentCompassEngine.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentCompassEngine.java
@@ -182,7 +182,7 @@ class LocationComponentCompassEngine implements CompassEngine, SensorEventListen
     SensorManager.getOrientation(adjustedRotationMatrix, orientation);
 
     if (orientation[1] < -Math.PI / 4) {
-      // The pitch is less than 45 degrees.
+      // The pitch is less than -45 degrees.
       // Remap the axes as if the device screen was the instrument panel,
       // and adjust the rotation matrix for the device orientation.
       switch (windowManager.getDefaultDisplay().getRotation()) {
@@ -202,6 +202,64 @@ class LocationComponentCompassEngine implements CompassEngine, SensorEventListen
         default:
           worldAxisForDeviceAxisX = SensorManager.AXIS_X;
           worldAxisForDeviceAxisY = SensorManager.AXIS_Z;
+          break;
+      }
+
+      SensorManager.remapCoordinateSystem(rotationMatrix, worldAxisForDeviceAxisX,
+              worldAxisForDeviceAxisY, adjustedRotationMatrix);
+
+      // Transform rotation matrix into azimuth/pitch/roll
+      SensorManager.getOrientation(adjustedRotationMatrix, orientation);
+    } else if (orientation[1] > Math.PI / 4) {
+      // The pitch is larger than 45 degrees.
+      // Remap the axes as if the device screen was upside down and facing back,
+      // and adjust the rotation matrix for the device orientation.
+      switch (windowManager.getDefaultDisplay().getRotation()) {
+        case Surface.ROTATION_90:
+          worldAxisForDeviceAxisX = SensorManager.AXIS_MINUS_Z;
+          worldAxisForDeviceAxisY = SensorManager.AXIS_MINUS_X;
+          break;
+        case Surface.ROTATION_180:
+          worldAxisForDeviceAxisX = SensorManager.AXIS_MINUS_X;
+          worldAxisForDeviceAxisY = SensorManager.AXIS_Z;
+          break;
+        case Surface.ROTATION_270:
+          worldAxisForDeviceAxisX = SensorManager.AXIS_Z;
+          worldAxisForDeviceAxisY = SensorManager.AXIS_X;
+          break;
+        case Surface.ROTATION_0:
+        default:
+          worldAxisForDeviceAxisX = SensorManager.AXIS_X;
+          worldAxisForDeviceAxisY = SensorManager.AXIS_MINUS_Z;
+          break;
+      }
+
+      SensorManager.remapCoordinateSystem(rotationMatrix, worldAxisForDeviceAxisX,
+              worldAxisForDeviceAxisY, adjustedRotationMatrix);
+
+      // Transform rotation matrix into azimuth/pitch/roll
+      SensorManager.getOrientation(adjustedRotationMatrix, orientation);
+    } else if (Math.abs(orientation[2]) > Math.PI / 2) {
+      // The roll is less than -90 degrees, or is larger than 90 degrees.
+      // Remap the axes as if the device screen was face down,
+      // and adjust the rotation matrix for the device orientation.
+      switch (windowManager.getDefaultDisplay().getRotation()) {
+        case Surface.ROTATION_90:
+          worldAxisForDeviceAxisX = SensorManager.AXIS_MINUS_Y;
+          worldAxisForDeviceAxisY = SensorManager.AXIS_MINUS_X;
+          break;
+        case Surface.ROTATION_180:
+          worldAxisForDeviceAxisX = SensorManager.AXIS_MINUS_X;
+          worldAxisForDeviceAxisY = SensorManager.AXIS_Y;
+          break;
+        case Surface.ROTATION_270:
+          worldAxisForDeviceAxisX = SensorManager.AXIS_Y;
+          worldAxisForDeviceAxisY = SensorManager.AXIS_X;
+          break;
+        case Surface.ROTATION_0:
+        default:
+          worldAxisForDeviceAxisX = SensorManager.AXIS_X;
+          worldAxisForDeviceAxisY = SensorManager.AXIS_MINUS_Y;
           break;
       }
 

--- a/MapboxGLAndroidSDK/src/main/res/drawable/mapbox_user_bearing_icon_unreliable.xml
+++ b/MapboxGLAndroidSDK/src/main/res/drawable/mapbox_user_bearing_icon_unreliable.xml
@@ -1,0 +1,10 @@
+<vector
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="44dp"
+  android:height="44dp"
+  android:viewportHeight="36.0"
+  android:viewportWidth="36.0">
+  <path
+    android:fillColor="#A1B0C0"
+    android:pathData="M18,0L23,7L13,7L18,0ZM22.8,7C21.33,6.36 19.71,6 18,6C16.29,6 14.67,6.36 13.2,7L22.8,7Z"/>
+</vector>

--- a/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/CompassEngineTest.java
+++ b/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/CompassEngineTest.java
@@ -58,7 +58,6 @@ public class CompassEngineTest {
   @Test
   public void whenGyroscopeIsNull_fallbackToGravity() {
     SensorManager sensorManager = mock(SensorManager.class);
-    when(sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE)).thenReturn(null);
     new LocationComponentCompassEngine(windowManager, sensorManager);
 
     verify(sensorManager, times(1)).getDefaultSensor(Sensor.TYPE_ACCELEROMETER);
@@ -67,7 +66,6 @@ public class CompassEngineTest {
   @Test
   public void whenGyroscopeIsNull_fallbackToMagneticField() {
     SensorManager sensorManager = mock(SensorManager.class);
-    when(sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE)).thenReturn(null);
     new LocationComponentCompassEngine(windowManager, sensorManager);
 
     verify(sensorManager, times(1)).getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD);


### PR DESCRIPTION
This PR fixes some compass related issues, and should be able to solve https://github.com/mapbox/mapbox-gl-native-android/issues/206.

I have also prepared a program to test the compass behavior:
https://github.com/ystsoi/mapbox-gl-native-android/tree/test-compass/TestCompass

There are several changes:
1) Remove the use of the deprecated TYPE_ORIENTATION sensor.
The heading will be wrong if this sensor is used and the device is not in its normal orientation. This can be seen using the test program. But, actually, I do not have any device which will drop to use this sensor, and I think that this sensor should be safe to remove.

2) Prevent dropping the TYPE_ACCELEROMETER and TYPE_MAGNETIC_FIELD sensor events.
The current logic only updates either gravityValues or magneticValues for each 500ms. As the calculation logic requires both gravityValues and magneticValues, and lowPassFilter is involved, so it should be better to process all sensor events, while just update the heading for each 500ms. I only have an old device not having the TYPE_ROTATION_VECTOR sensor, and will use these sensors, so I suppose that most devices will not be affected by this change.

3) Calculate the heading differently, depending on whether the device is placed horizontally or vertically.
The current logic only works well when the device is placed vertically, like for car navigation. But it does not show a reliable heading when the device is placed horizontally. For example, if a group of hikers use the same Mapbox app, they may get different direction info, depending on how they hold their phones. The fix uses the pitch to determine how to calculate the heading. The fix is based on the existing logic, SensorManager API doc, and test results. There is not much documentation on this subject, but you may try the test program to see the effect of the new logic.

4) Update the heading, even if the sensor is unreliable.
The current logic will stop rotating the heading if the sensor is unreliable. To prevent user confusion, developers can either hide the heading, or help to do calibration. The change keeps updating the heading, even if the sensor is unreliable. This makes it possible to use a different, like a gray-out, indicator for the unreliable heading. As sometimes it is difficult to calibrate, the sensor keeps providing unreliable values. Developers can still hide the heading, if they like.

5) Add the mapbox_user_bearing_icon_unreliable drawable for convenience.
The drawable is not used by the SDK. Developers can just switch between mapbox_user_bearing_icon and mapbox_user_bearing_icon_unreliable, and do not need to draw their own icon. mapbox_user_bearing_icon_unreliable is just a gray-out mapbox_user_bearing_icon. See whether it is OK to add it to the SDK.

Please review.