### PR TITLE
Add api and demo for expression distance

### DIFF
--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
@@ -8,6 +8,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+import com.mapbox.geojson.GeoJson;
 import com.mapbox.geojson.Polygon;
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
 import com.mapbox.mapboxsdk.style.layers.PropertyValue;
@@ -1572,6 +1573,42 @@ public class Expression {
    */
   public static Expression in(@NonNull String needle, @NonNull Expression haystack) {
     return new Expression("in", literal(needle), haystack);
+  }
+
+  /**
+   * Retrieves the shortest distance between two geometries.
+   * The returned value can be consumed as an input into another expression for changing a paint or layout property
+   * or filtering features by distance.
+   *
+   * @param geoJson the target feature geoJso.
+   *                Currently supports `Point`, `MultiPoint`, `LineString`, `MultiLineString` geometry types
+   * @param unit    the unit for the returned value.
+   *                Currently supports `metres`, `kilometers`, `miles`, `nauticalmiles`, "yards"，"feet"，"inches"。
+   * @return the distance in the unit that is provided.
+   * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-distance">Style specification</a>
+   */
+  public static Expression distance(@NonNull GeoJson geoJson, String unit) {
+    Map<String, Expression> map = new HashMap<>();
+    map.put("json", literal(geoJson.toJson()));
+    return new Expression("distance", new ExpressionMap(map), literal(unit));
+  }
+
+  /**
+   * Retrieves the shortest distance between two geometries.
+   * The returned value can be consumed as an input into another expression for changing a paint or layout property
+   * or filtering features by distance.
+   * <p>
+   * Currently supports `Point`, `MultiPoint`, `LineString`, `MultiLineString` geometry types.
+   *
+   * @param geoJson the target feature geoJson.
+   *                Currently supports `Point`, `MultiPoint`, `LineString`, `MultiLineString` geometry types
+   * @return the distance in the unit "meters".
+   * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-distance">Style specification</a>
+   */
+  public static Expression distance(@NonNull GeoJson geoJson) {
+    Map<String, Expression> map = new HashMap<>();
+    map.put("json", literal(geoJson.toJson()));
+    return new Expression("distance", new ExpressionMap(map));
   }
 
   public static Expression within(@NonNull Polygon polygon) {

--- a/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/style/expressions/ExpressionTest.java
+++ b/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/style/expressions/ExpressionTest.java
@@ -492,11 +492,13 @@ public class ExpressionTest {
   @Test
   public void testDistance() throws Exception {
     Point point = Point.fromLngLat(1, 2);
-    Object[] expected = new Object[] {"distance", point.toJson()};
+    HashMap<String, String> map = new HashMap<>();
+    map.put("json", point.toJson());
+    Object[] expected = new Object[] {"distance", map};
     Object[] actual = distance(point).toArray();
     assertTrue("expression should match", Arrays.deepEquals(expected, actual));
 
-    Object[] expectedWithUnit = new Object[] {"distance", point.toJson(), "meters"};
+    Object[] expectedWithUnit = new Object[] {"distance", map, "meters"};
     Object[] actualWithUnit = distance(point, "meters").toArray();
     assertTrue("expression should match", Arrays.deepEquals(expectedWithUnit, actualWithUnit));
   }

--- a/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/style/expressions/ExpressionTest.java
+++ b/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/style/expressions/ExpressionTest.java
@@ -37,6 +37,7 @@ import static com.mapbox.mapboxsdk.style.expressions.Expression.color;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.concat;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.cos;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.cubicBezier;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.distance;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.division;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.downcase;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.e;
@@ -486,6 +487,20 @@ public class ExpressionTest {
     Object[] actual = in(literal(1f), literal(new Object[] {1f, 2f})).toArray();
     assertTrue("expression should match", Arrays.deepEquals(expected, actual));
   }
+
+
+  @Test
+  public void testDistance() throws Exception {
+    Point point = Point.fromLngLat(1, 2);
+    Object[] expected = new Object[] {"distance", point.toJson()};
+    Object[] actual = distance(point).toArray();
+    assertTrue("expression should match", Arrays.deepEquals(expected, actual));
+
+    Object[] expectedWithUnit = new Object[] {"distance", point.toJson(), "meters"};
+    Object[] actualWithUnit = distance(point, "meters").toArray();
+    assertTrue("expression should match", Arrays.deepEquals(expectedWithUnit, actualWithUnit));
+  }
+
 
   @Test
   public void testInArray() throws Exception {

--- a/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
+++ b/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
@@ -516,6 +516,18 @@
                 android:value=".activity.FeatureOverviewActivity" />
         </activity>
         <activity
+            android:name=".activity.style.DistanceExpressionActivity"
+            android:description="@string/description_distance_style"
+            android:exported="true"
+            android:label="@string/activity_distance_style">
+            <meta-data
+                android:name="@string/category"
+                android:value="@string/category_style" />
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".activity.FeatureOverviewActivity" />
+        </activity>
+        <activity
             android:name=".activity.style.GradientLineActivity"
             android:description="@string/description_gradient_line"
             android:exported="true"

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/DistanceExpressionActivity.kt
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/DistanceExpressionActivity.kt
@@ -1,0 +1,129 @@
+package com.mapbox.mapboxsdk.testapp.activity.style
+
+import android.graphics.Color
+import android.os.Bundle
+import android.os.PersistableBundle
+import androidx.appcompat.app.AppCompatActivity
+import com.mapbox.geojson.Point
+import com.mapbox.mapboxsdk.camera.CameraPosition
+import com.mapbox.mapboxsdk.geometry.LatLng
+import com.mapbox.mapboxsdk.maps.MapboxMap
+import com.mapbox.mapboxsdk.maps.Style
+import com.mapbox.mapboxsdk.style.expressions.Expression.distance
+import com.mapbox.mapboxsdk.style.expressions.Expression.lt
+import com.mapbox.mapboxsdk.style.layers.FillLayer
+import com.mapbox.mapboxsdk.style.layers.Property.NONE
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory.*
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer
+import com.mapbox.mapboxsdk.style.sources.GeoJsonSource
+import com.mapbox.mapboxsdk.testapp.R
+import com.mapbox.turf.TurfConstants
+import com.mapbox.turf.TurfTransformation
+import kotlinx.android.synthetic.main.activity_physical_circle.*
+
+/**
+ * An Activity that showcases the within expression to filter features outside a geometry
+ */
+class DistanceExpressionActivity : AppCompatActivity() {
+
+  private lateinit var mapboxMap: MapboxMap
+
+  private val lat = 37.78794572301525
+  private val lon = -122.40752220153807
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContentView(R.layout.activity_within_expression)
+
+    mapView.onCreate(savedInstanceState)
+    mapView.getMapAsync { map ->
+      mapboxMap = map
+
+      // Setup camera position above Georgetown
+      mapboxMap.cameraPosition = CameraPosition.Builder()
+        .target(LatLng(lat, lon))
+        .zoom(16.0)
+        .build()
+      setupStyle()
+    }
+  }
+
+  private fun setupStyle() {
+    val center = Point.fromLngLat(lon, lat)
+    val circle = TurfTransformation.circle(center, 150.0, TurfConstants.UNIT_METRES)
+    // Setup style with additional layers,
+    // using Style.MAPBOX_STREETS as a base style
+    mapboxMap.setStyle(
+      Style.Builder()
+        .fromUri(Style.MAPBOX_STREETS)
+        .withSources(
+          GeoJsonSource(
+            POINT_ID, Point.fromLngLat(lon, lat)
+          ),
+          GeoJsonSource(CIRCLE_ID, circle)
+        )
+        .withLayerBelow(
+          FillLayer(CIRCLE_ID, CIRCLE_ID)
+            .withProperties(
+              fillOpacity(0.5f),
+              fillColor(Color.parseColor("#3bb2d0"))
+            ), "poi-label"
+        )
+    ) { style ->
+      // Show only POI labels inside circle radius using distance expression
+      val symbolLayer = style.getLayer("poi-label") as SymbolLayer
+      symbolLayer.setFilter(lt(
+        distance(
+          Point.fromLngLat(lon, lat), "meters"
+        ), 150)
+      )
+
+      // Hide other types of labels to highlight POI labels
+      (style.getLayer("road-label") as SymbolLayer).setProperties(visibility(NONE))
+      (style.getLayer("transit-label") as SymbolLayer).setProperties(visibility(NONE))
+      (style.getLayer("road-number-shield") as SymbolLayer).setProperties(visibility(NONE))
+    }
+  }
+
+  override fun onStart() {
+    super.onStart()
+    mapView.onStart()
+  }
+
+  override fun onResume() {
+    super.onResume()
+    mapView.onResume()
+  }
+
+  override fun onPause() {
+    super.onPause()
+    mapView.onPause()
+  }
+
+  override fun onStop() {
+    super.onStop()
+    mapView.onStop()
+  }
+
+  override fun onLowMemory() {
+    super.onLowMemory()
+    mapView.onLowMemory()
+  }
+
+  override fun onDestroy() {
+    super.onDestroy()
+    mapView.onDestroy()
+  }
+
+  override fun onSaveInstanceState(outState: Bundle?, outPersistentState: PersistableBundle?) {
+    super.onSaveInstanceState(outState, outPersistentState)
+    outState?.let {
+      mapView.onSaveInstanceState(it)
+    }
+  }
+
+  companion object {
+    const val POINT_ID = "point"
+    const val CIRCLE_ID = "circle"
+  }
+}

--- a/MapboxGLAndroidSDKTestApp/src/main/res/values/descriptions.xml
+++ b/MapboxGLAndroidSDKTestApp/src/main/res/values/descriptions.xml
@@ -34,6 +34,7 @@
     <string name="description_dynamic_info_window_adapter">Learn how to create a dynamic custom InfoWindow</string>
     <string name="description_viewpager">Use SupportMapFragments in a ViewPager</string>
     <string name="description_runtime_style">Adopt the map style on the fly</string>
+    <string name="description_distance_style">Show POIs on a map with distance expression filter</string>
     <string name="description_gradient_line">Show a gradient line layer from a geojson source</string>
     <string name="description_data_driven_style">Use functions to change the map appearance</string>
     <string name="description_symbol_layer">Manipulate symbols at runtime</string>

--- a/MapboxGLAndroidSDKTestApp/src/main/res/values/titles.xml
+++ b/MapboxGLAndroidSDKTestApp/src/main/res/values/titles.xml
@@ -32,6 +32,7 @@
     <string name="activity_minmax_zoom">Min/Max Zoom</string>
     <string name="activity_viewpager">ViewPager</string>
     <string name="activity_runtime_style">Runtime Style</string>
+    <string name="activity_distance_style">Distance Expression</string>
     <string name="activity_gradient_line">Gradient line layer</string>
     <string name="activity_data_driven_style">Data Driven Style</string>
     <string name="activity_circle_layer">Circle layer</string>


### PR DESCRIPTION
`<changelog>Add api to support expression distance. Users can use this expression to calculate the shortest distance between the geoObject input and the feature geometry</changelog>`

Fixes #336 
![image](https://user-images.githubusercontent.com/8577318/80183139-e071c900-863a-11ea-8d72-9e4f1005433b.png)
