### PR TITLE
Fix fast fling issue on devices with low-density screen

### DIFF
--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
@@ -66,7 +66,7 @@ public class MapboxConstants {
   /**
    * Animation time of a fling gesture
    */
-  public static final long ANIMATION_DURATION_FLING_BASE = ANIMATION_DURATION;
+  public static final long ANIMATION_DURATION_FLING_BASE = 500;
 
   /**
    * Velocity threshold for a fling gesture

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
@@ -66,12 +66,12 @@ public class MapboxConstants {
   /**
    * Animation time of a fling gesture
    */
-  public static final long ANIMATION_DURATION_FLING_BASE = ANIMATION_DURATION_SHORT;
+  public static final long ANIMATION_DURATION_FLING_BASE = ANIMATION_DURATION;
 
   /**
    * Velocity threshold for a fling gesture
    */
-  public static final long VELOCITY_THRESHOLD_IGNORE_FLING = 1000;
+  public static final long VELOCITY_THRESHOLD_IGNORE_FLING = 300;
 
   /**
    * Vertical angle threshold for a horizontal disabled fling gesture

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
@@ -428,8 +428,8 @@ final class MapGestureDetector {
       // tilt results in a bigger translation, limiting input for #5281
       double tilt = transform.getTilt();
       double tiltFactor = 1.5 + ((tilt != 0) ? (tilt / 10) : 0);
-      double offsetX = velocityX / tiltFactor / screenDensity;
-      double offsetY = velocityY / tiltFactor / screenDensity;
+      double offsetX = velocityX / tiltFactor / 3;
+      double offsetY = velocityY / tiltFactor / 3;
 
       // calculate animation time based on displacement
       long animationTime = (long) (velocityXY / 7 / tiltFactor + MapboxConstants.ANIMATION_DURATION_FLING_BASE);


### PR DESCRIPTION
I found that fling gesture will cause a larger movement on devices with lower density screen, which makes Mapbox not work well on those devices. By the proposed change in MapGestureDetector, the issue can be fixed. But I am not sure whether this is the appropriate place to fix, it depends on what input transform.moveBy expects. Please review.

I have also tuned some fling related constant. I use a lower VELOCITY_THRESHOLD_IGNORE_FLING to allow some short flings. This makes map pan appear smoother. And it seems not good that even the minimum fling will cause a large distance movement. Also, a longer ANIMATION_DURATION_FLING_BASE is used to prevent fast moving short flings. See whether you agree on the settings.