### PR TITLE
Update gralde configure to only build the target abi.

### DIFF
--- a/gradle/native-build.gradle
+++ b/gradle/native-build.gradle
@@ -58,7 +58,7 @@ ext.nativeBuild = { nativeTargets ->
                         if (abi != 'all') {
                             abiFilters abi.split(' ')
                         } else {
-                            if (project.hasProperty('android.injected.invoked.from.ide')) {
+                            if (project.hasProperty('android.injected.invoked.from.ide') && project.hasProperty('android.injected.build.abi')) {
                                 //Only build the target abi while running from Android studio
                                 abi = project.getProperty("android.injected.build.abi")
                                 abiFilters abi.split(',').first()

--- a/gradle/native-build.gradle
+++ b/gradle/native-build.gradle
@@ -58,7 +58,13 @@ ext.nativeBuild = { nativeTargets ->
                         if (abi != 'all') {
                             abiFilters abi.split(' ')
                         } else {
-                            abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
+                            if (project.hasProperty('android.injected.invoked.from.ide')) {
+                                //Only build the target abi while running from Android studio
+                                abi = project.getProperty("android.injected.build.abi")
+                                abiFilters abi.split(',').first()
+                            } else {
+                                abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
In the past, android studio will build all 4 abis if we switch branches in gl-native. 
This pr will fix this issue by getting the target abi and only build this one to accelerate the build process. 
Fixs #337 