### PR TITLE
Expose gesture protection area when tracking location

### DIFF
--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
@@ -410,8 +410,6 @@ final class MapGestureDetector {
         return false;
       }
 
-      notifyOnFlingListeners();
-
       if (!uiSettings.isFlingVelocityAnimationEnabled()) {
         return false;
       }
@@ -443,6 +441,7 @@ final class MapGestureDetector {
       }
 
       transform.cancelTransitions();
+      notifyOnFlingListeners();
       cameraChangeDispatcher.onCameraMoveStarted(REASON_API_GESTURE);
 
       // update transformation

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationModesActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationModesActivity.java
@@ -2,6 +2,7 @@ package com.mapbox.mapboxsdk.testapp.activity.location;
 
 import android.annotation.SuppressLint;
 import android.content.res.Configuration;
+import android.graphics.RectF;
 import android.location.Location;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
@@ -9,6 +10,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.ListPopupWindow;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.Toast;
@@ -39,6 +41,7 @@ public class LocationModesActivity extends AppCompatActivity implements OnMapRea
   private MapView mapView;
   private Button locationModeBtn;
   private Button locationTrackingBtn;
+  private View protectedGestureArea;
 
   private PermissionsManager permissionsManager;
 
@@ -64,6 +67,7 @@ public class LocationModesActivity extends AppCompatActivity implements OnMapRea
     setContentView(R.layout.activity_location_layer_mode);
 
     mapView = findViewById(R.id.mapView);
+    protectedGestureArea = findViewById(R.id.view_protected_gesture_area);
 
     locationModeBtn = findViewById(R.id.button_location_mode);
     locationModeBtn.setOnClickListener(v -> {
@@ -245,6 +249,9 @@ public class LocationModesActivity extends AppCompatActivity implements OnMapRea
       return;
     }
 
+    protectedGestureArea.getLayoutParams().height = 0;
+    protectedGestureArea.getLayoutParams().width = 0;
+
     LocationComponentOptions options = locationComponent
       .getLocationComponentOptions()
       .toBuilder()
@@ -258,10 +265,16 @@ public class LocationModesActivity extends AppCompatActivity implements OnMapRea
       return;
     }
 
+    RectF rectF = new RectF(0f, 0f, mapView.getWidth() / 2f, mapView.getHeight() / 2f);
+    protectedGestureArea.getLayoutParams().height = (int) rectF.bottom;
+    protectedGestureArea.getLayoutParams().width = (int) rectF.right;
+
     LocationComponentOptions options = locationComponent
       .getLocationComponentOptions()
       .toBuilder()
       .trackingGesturesManagement(true)
+      .trackingMultiFingerProtectedMoveArea(rectF)
+      .trackingMultiFingerMoveThreshold(500)
       .build();
     locationComponent.applyStyle(options);
   }

--- a/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_location_layer_mode.xml
+++ b/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_location_layer_mode.xml
@@ -16,6 +16,15 @@
         app:layout_constraintTop_toTopOf="parent"
         app:mapbox_uiAttribution="false" />
 
+    <View
+        android:id="@+id/view_protected_gesture_area"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:alpha="0.5"
+        android:background="@android:color/holo_red_light"
+        app:layout_constraintStart_toStartOf="@id/mapView"
+        app:layout_constraintTop_toTopOf="@id/mapView" />
+
     <LinearLayout
         android:id="@+id/linearLayout"
         style="?android:attr/buttonBarStyle"

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ allprojects {
         // For publishing Maps SDK files to Bintray
         maven { url 'https://mapbox.bintray.com/mapbox' }
         // Snapshot repository
-        // maven { url 'https://oss.jfrog.org/artifactory/oss-snapshot-local/' }
+         maven { url 'https://oss.jfrog.org/artifactory/oss-snapshot-local/' }
     }
     apply from: "${rootDir}/gradle/ktlint.gradle"
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -10,7 +10,7 @@ ext {
             mapboxServices  : '5.0.0',
             mapboxTelemetry : '5.0.0',
             mapboxCore      : '2.0.0',
-            mapboxGestures  : '0.6.0',
+            mapboxGestures  : '0.6.0-20200429.121422-14',
             mapboxAccounts  : '0.7.0',
             appCompat       : '1.0.0',
             constraintLayout: '1.1.3',


### PR DESCRIPTION
This PR brings 2 changes:
```
<changelog>Expose a `LocationComponentOptions#trackingMultiFingerProtectedMoveArea`. When the screen area is provided and `LocationComponentOptions#trackingGesturesManagement` is enabled, any gesture executed within this area will try avoiding breaking the tracking. </changelog>
```
```
<changelog>Fix an issue where the `onFling` listener was called even when the velocity of the gesture did not meet the threshold to actually animate the camera</changelog>
```
![ezgif com-optimize (26)](https://user-images.githubusercontent.com/16925074/80607074-560fd780-8a35-11ea-9eca-5df177b09ac8.gif)

Currently, the PR is based on the gesture's lib snapshot but whenever the changes are accepted, I'll bump the version of the library to a stable one.