### PR TITLE
Add SDK license file to script and generate new license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,13 +1,13 @@
 <!-- This file was generated. Use `make android-license` to update. -->  
 mapbox-gl-native-android copyright 2014-2020 Mapbox. 
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the followingconditions are met:  
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:  
 
 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.  
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the followingdisclaimer in the documentation and/or other materials provided with the distribution.  
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.  
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIEDWARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR APARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FORANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITEDTO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDINGNEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITYOF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ===========================================================================
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,237 +1,248 @@
 <!-- This file was generated. Use `make android-license` to update. -->  
-## Additional Mapbox GL licenses  
-Mapbox GL uses portions of the Android Arch-Common.  
+mapbox-gl-native-android copyright 2014-2020 Mapbox. 
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the followingconditions are met:  
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.  
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the followingdisclaimer in the documentation and/or other materials provided with the distribution.  
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIEDWARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR APARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FORANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITEDTO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDINGNEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITYOF SUCH DAMAGE.
+
+===========================================================================
+
+Mapbox GL uses portions of Android Arch-Common.  
 URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Arch-Runtime.  
+Mapbox GL uses portions of Android Arch-Runtime.  
 URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Lifecycle LiveData.  
+Mapbox GL uses portions of Android Lifecycle LiveData.  
 URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Lifecycle LiveData Core.  
+Mapbox GL uses portions of Android Lifecycle LiveData Core.  
 URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Lifecycle Runtime.  
+Mapbox GL uses portions of Android Lifecycle Runtime.  
 URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Lifecycle ViewModel.  
+Mapbox GL uses portions of Android Lifecycle ViewModel.  
 URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Lifecycle-Common.  
+Mapbox GL uses portions of Android Lifecycle-Common.  
 URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Support Library Annotations.  
+Mapbox GL uses portions of Android Support Library Annotations.  
 URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Support Library Async Layout Inflater.  
+Mapbox GL uses portions of Android Support Library Async Layout Inflater.  
 URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Support Library collections.  
+Mapbox GL uses portions of Android Support Library collections.  
 URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Support Library compat.  
+Mapbox GL uses portions of Android Support Library compat.  
 URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Support Library Coordinator Layout.  
+Mapbox GL uses portions of Android Support Library Coordinator Layout.  
 URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Support Library core UI.  
+Mapbox GL uses portions of Android Support Library core UI.  
 URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Support Library core utils.  
+Mapbox GL uses portions of Android Support Library core utils.  
 URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Support Library Cursor Adapter.  
+Mapbox GL uses portions of Android Support Library Cursor Adapter.  
 URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Support Library Custom View.  
+Mapbox GL uses portions of Android Support Library Custom View.  
 URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Support Library Custom View.  
+Mapbox GL uses portions of Android Support Library Custom View.  
 URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Support Library Document File.  
+Mapbox GL uses portions of Android Support Library Document File.  
 URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Support Library Drawer Layout.  
+Mapbox GL uses portions of Android Support Library Drawer Layout.  
 URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Support Library fragment.  
+Mapbox GL uses portions of Android Support Library fragment.  
 URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Support Library Interpolators.  
+Mapbox GL uses portions of Android Support Library Interpolators.  
 URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Support Library loader.  
+Mapbox GL uses portions of Android Support Library loader.  
 URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Support Library Local Broadcast Manager.  
+Mapbox GL uses portions of Android Support Library Local Broadcast Manager.  
 URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Support Library Print.  
+Mapbox GL uses portions of Android Support Library Print.  
 URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Support Library Sliding Pane Layout.  
+Mapbox GL uses portions of Android Support Library Sliding Pane Layout.  
 URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Android Support Library View Pager.  
+Mapbox GL uses portions of Android Support Library View Pager.  
 URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Gson.  
+Mapbox GL uses portions of Gson.  
 License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Mapbox Accounts SDK for Android.  
+Mapbox GL uses portions of Mapbox Accounts SDK for Android.  
 URL: [https://github.com/mapbox/mapbox-accounts-android](https://github.com/mapbox/mapbox-accounts-android)  
 License: [Mapbox Terms of Service](https://www.mapbox.com/tos/)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Mapbox Android Core Library.  
+Mapbox GL uses portions of Mapbox Android Core Library.  
 URL: [https://github.com/mapbox/mapbox-events-android](https://github.com/mapbox/mapbox-events-android)  
 License: [The MIT License](https://opensource.org/licenses/MIT)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Mapbox Android Gestures Library.  
+Mapbox GL uses portions of Mapbox Android Gestures Library.  
 URL: [https://github.com/mapbox/mapbox-gestures-android](https://github.com/mapbox/mapbox-gestures-android)  
 License: [BSD](https://opensource.org/licenses/BSD-2-Clause)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Mapbox Android Telemetry Library.  
+Mapbox GL uses portions of Mapbox Android Telemetry Library.  
 URL: [https://github.com/mapbox/mapbox-events-android](https://github.com/mapbox/mapbox-events-android)  
 License: [The MIT License](https://opensource.org/licenses/MIT)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Mapbox Java SDK.  
+Mapbox GL uses portions of Mapbox Java SDK.  
 URL: [https://github.com/mapbox/mapbox-java](https://github.com/mapbox/mapbox-java)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Mapbox Java SDK.  
+Mapbox GL uses portions of Mapbox Java SDK.  
 URL: [https://github.com/mapbox/mapbox-java](https://github.com/mapbox/mapbox-java)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the OkHttp.  
+Mapbox GL uses portions of OkHttp.  
 License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Okio.  
+Mapbox GL uses portions of Okio.  
 License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the SoLoader.  
+Mapbox GL uses portions of SoLoader.  
 URL: [https://github.com/facebook/soloader](https://github.com/facebook/soloader)  
 License: [Apache-2](https://github.com/facebook/soloader/blob/master/LICENSE)
 
 ===========================================================================
 
-Mapbox GL uses portions of the SoLoader.  
+Mapbox GL uses portions of SoLoader.  
 URL: [https://github.com/facebook/soloader](https://github.com/facebook/soloader)  
 License: [Apache-2](https://github.com/facebook/soloader/blob/master/LICENSE)
 
 ===========================================================================
 
-Mapbox GL uses portions of the SoLoader.  
+Mapbox GL uses portions of SoLoader.  
 URL: [https://github.com/facebook/soloader](https://github.com/facebook/soloader)  
 License: [Apache-2](https://github.com/facebook/soloader/blob/master/LICENSE)
 
 ===========================================================================
 
-Mapbox GL uses portions of the VersionedParcelable and friends.  
+Mapbox GL uses portions of VersionedParcelable and friends.  
 URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of the Gradle License Plugin.  
+Mapbox GL uses portions of Gradle License Plugin.  
 URL: [https://github.com/jaredsburrows/gradle-license-plugin](https://github.com/jaredsburrows/gradle-license-plugin)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 

--- a/scripts/generate-license.py
+++ b/scripts/generate-license.py
@@ -6,21 +6,21 @@ import json
 path = os.getcwd()
 with open(path + "/LICENSE.md", 'w') as licenseFile:
     licenseFile.write("<!-- This file was generated. Use `make android-license` to update. -->  \n")
-    licenseFile.write("mapbox-gl-native-android copyright 2014-2020 Mapbox. \n"
+    licenseFile.write("mapbox-gl-native-android copyright 2014-2020 Mapbox. \n\n"
     "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following"
     "conditions are met:  \n\n"
     "1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.  \n\n"
-    "2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+    "2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following"
     "disclaimer in the documentation and/or other materials provided with the distribution.  \n\n"
     "THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\" AND ANY EXPRESS OR IMPLIED"
     "WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A"
     "PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR"
     "ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED"
-    "TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)""
+    "TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)"
     "HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING"
     "NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY"
-    "OF SUCH DAMAGE.  \n\n")
-    licenseFile.write("===========================================================================  \n\n")
+    "OF SUCH DAMAGE.")
+    licenseFile.write("\n\n===========================================================================\n\n")
     with open(path + "/MapboxGLAndroidSDK/build/reports/licenses/licenseReleaseReport.json", 'r') as dataFile:
         data = json.load(dataFile)
 
@@ -50,4 +50,4 @@ with open(path + "/LICENSE.md", 'w') as licenseFile:
             licenseFile.write("Mapbox GL uses portions of %s.  \n" % projectName +
                               ("URL: [%s](%s)  \n" % (projectUrl, projectUrl) if projectUrl is not None else "") +
                               "License: [%s](%s)" % (licenseName, licenseUrl) +
-                              "\n\n===========================================================================  \n\n")
+                              "\n\n===========================================================================\n\n")

--- a/scripts/generate-license.py
+++ b/scripts/generate-license.py
@@ -6,7 +6,21 @@ import json
 path = os.getcwd()
 with open(path + "/LICENSE.md", 'w') as licenseFile:
     licenseFile.write("<!-- This file was generated. Use `make android-license` to update. -->  \n")
-    licenseFile.write("## Additional Mapbox GL licenses  \n")
+    licenseFile.write("mapbox-gl-native-android copyright 2014-2020 Mapbox. \n"
+    "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following"
+    "conditions are met:  \n\n"
+    "1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.  \n\n"
+    "2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+    "disclaimer in the documentation and/or other materials provided with the distribution.  \n\n"
+    "THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\" AND ANY EXPRESS OR IMPLIED"
+    "WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A"
+    "PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR"
+    "ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED"
+    "TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)""
+    "HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING"
+    "NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY"
+    "OF SUCH DAMAGE.  \n\n")
+    licenseFile.write("===========================================================================  \n\n")
     with open(path + "/MapboxGLAndroidSDK/build/reports/licenses/licenseReleaseReport.json", 'r') as dataFile:
         data = json.load(dataFile)
 
@@ -33,7 +47,7 @@ with open(path + "/LICENSE.md", 'w') as licenseFile:
                 licenseName = license["license"]
                 licenseUrl = license["license_url"]
 
-            licenseFile.write("Mapbox GL uses portions of the %s.  \n" % projectName +
+            licenseFile.write("Mapbox GL uses portions of %s.  \n" % projectName +
                               ("URL: [%s](%s)  \n" % (projectUrl, projectUrl) if projectUrl is not None else "") +
                               "License: [%s](%s)" % (licenseName, licenseUrl) +
-                              "\n\n===========================================================================\n\n")
+                              "\n\n===========================================================================  \n\n")

--- a/scripts/generate-license.py
+++ b/scripts/generate-license.py
@@ -7,18 +7,18 @@ path = os.getcwd()
 with open(path + "/LICENSE.md", 'w') as licenseFile:
     licenseFile.write("<!-- This file was generated. Use `make android-license` to update. -->  \n")
     licenseFile.write("mapbox-gl-native-android copyright 2014-2020 Mapbox. \n\n"
-    "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following"
+    "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following "
     "conditions are met:  \n\n"
     "1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.  \n\n"
-    "2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following"
+    "2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following "
     "disclaimer in the documentation and/or other materials provided with the distribution.  \n\n"
-    "THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\" AND ANY EXPRESS OR IMPLIED"
-    "WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A"
-    "PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR"
-    "ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED"
-    "TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)"
-    "HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING"
-    "NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY"
+    "THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\" AND ANY EXPRESS OR IMPLIED "
+    "WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A "
+    "PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR "
+    "ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED "
+    "TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) "
+    "HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING "
+    "NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY "
     "OF SUCH DAMAGE.")
     licenseFile.write("\n\n===========================================================================\n\n")
     with open(path + "/MapboxGLAndroidSDK/build/reports/licenses/licenseReleaseReport.json", 'r') as dataFile:


### PR DESCRIPTION
Updated the license script to have parity with the LICENSE.md file in @mapbox/maps-ios.

Fixes https://github.com/mapbox/mapbox-gl-native-android/issues/362

cc @zugaldia @langsmith @knov 