### PR TITLE
Reset AndroidRendererBackend properly to prevent a crash during rotation on an Android 4.2.2 x86 tablet

### DIFF
--- a/MapboxGLAndroidSDK/src/cpp/map_renderer.cpp
+++ b/MapboxGLAndroidSDK/src/cpp/map_renderer.cpp
@@ -122,6 +122,7 @@ void MapRenderer::requestSnapshot(SnapshotCallback callback) {
 
 void MapRenderer::resetRenderer() {
     renderer.reset();
+    backend.reset();
 }
 
 void MapRenderer::scheduleSnapshot(std::unique_ptr<SnapshotCallback> callback) {


### PR DESCRIPTION
The PR fixed a crash which occurred on an Android 4.2.2 x86 tablet during orientation change.

The error was:
```
libEGL: call to OpenGL ES API with no current context (logged once per thread)
```
It occurred during the execution of the destructor of Context.

After traced some function calls, I noticed that the destructor of Context did not get called, even though renderer is reset in MapRenderer.resetRenderer. And as Context is actually held by RendererBackend, so I thought that AndroidRendererBackend should need to be reset too. I do not really understand the renderer logic.

Please review.

Here is the crash log for a test program using Mapbox 9.1.0:
```
com.test.testx86tabletcrash I/dalvikvm: JIT_INFO: VRDELAY_CAN_THROW cancel was not optimized for bytecode=0xdb
com.test.testx86tabletcrash I/Mbgl-EGLConfigChooser: In emulator: false
com.test.testx86tabletcrash V/Mbgl-ConnectivityReceiver: connected - true
com.test.testx86tabletcrash I/dalvikvm: Total arena pages for JIT: 17
com.test.testx86tabletcrash I/dalvikvm: Total arena pages for JIT: 18
com.test.testx86tabletcrash I/dalvikvm: Total arena pages for JIT: 19
com.test.testx86tabletcrash D/dalvikvm: GC_FOR_ALLOC freed 4787K, 35% free 10400K/15812K, paused 13ms, total 13ms
com.test.testx86tabletcrash E/libEGL: call to OpenGL ES API with no current context (logged once per thread)
com.test.testx86tabletcrash A/libc: Fatal signal 11 (SIGSEGV) at 0x0000080c (code=1), thread 3738 (FinalizerDaemon)
I/DEBUG: *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
I/DEBUG: Build fingerprint: 'Teclast/Teclast/x983g_hkc1:4.2.2/JDQ39/eng.yankendi.20140429.184832:userdebug/dev-keys'
I/DEBUG: Revision: '0'
I/DEBUG: pid: 3729, tid: 3738, name: FinalizerDaemon  >>> com.test.testx86tabletcrash <<<
I/DEBUG: signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0000080c
I/DEBUG:     eax 00000000  ebx 77b4b408  ecx 00000015  edx 00000015
I/DEBUG:     esi 7819eca0  edi 00000000
I/DEBUG:     xcs 00000073  xds 0000007b  xes 0000007b  xfs 00000000  xss 0000007b
I/DEBUG:     eip 77986530  ebp 752579f8  esp 752579e0  flags 00010293
I/DEBUG: backtrace:
I/DEBUG:     #00  pc 009b8530  /system/lib/egl/libGLES_intel7.so (glDeleteVertexArraysOES+48)
I/DEBUG:     #01  pc 0023a64c  /data/app-lib/com.test.testx86tabletcrash-1/libmapbox-gl.so
I/DEBUG:     #02  pc 0023a2f3  /data/app-lib/com.test.testx86tabletcrash-1/libmapbox-gl.so
I/DEBUG: stack:
I/DEBUG:          752579a0  00000000  
I/DEBUG:          752579a4  00000000  
I/DEBUG:          752579a8  00000000  
I/DEBUG:          752579ac  00000000  
I/DEBUG:          752579b0  00000000  
I/DEBUG:          752579b4  00000000  
I/DEBUG:          752579b8  00000000  
I/DEBUG:          752579bc  00000000  
I/DEBUG:          752579c0  00000000  
I/DEBUG:          752579c4  00000000  
I/DEBUG:          752579c8  00000000  
I/DEBUG:          752579cc  00000000  
I/DEBUG:          752579d0  00000000  
I/DEBUG:          752579d4  00000000  
I/DEBUG:          752579d8  00000000  
I/DEBUG:          752579dc  00000000  
I/DEBUG:     #00  752579e0  00000015  
I/DEBUG:          752579e4  77f526c0  
I/DEBUG:          752579e8  75257a38  [stack:3738]
I/DEBUG:          752579ec  76241fa8  /data/app-lib/com.test.testx86tabletcrash-1/libmapbox-gl.so
I/DEBUG:          752579f0  77986509  /system/lib/egl/libGLES_intel7.so (glDeleteVertexArraysOES+9)
I/DEBUG:          752579f4  76241fa8  /data/app-lib/com.test.testx86tabletcrash-1/libmapbox-gl.so
I/DEBUG:          752579f8  75257a38  [stack:3738]
I/DEBUG:          752579fc  7602764c  /data/app-lib/com.test.testx86tabletcrash-1/libmapbox-gl.so
I/DEBUG:     #01  75257a00  00000015  
I/DEBUG:          75257a04  77f526c0  
I/DEBUG:          75257a08  793bb8d0  
I/DEBUG:          75257a0c  4010d724  
I/DEBUG:          75257a10  7819ed20  
I/DEBUG:          75257a14  00000000  
I/DEBUG:          75257a18  8657ae9a  
I/DEBUG:          75257a1c  75f0e7e3  /data/app-lib/com.test.testx86tabletcrash-1/libmapbox-gl.so
I/DEBUG:          75257a20  781e2320  
I/DEBUG:          75257a24  76241fa8  /data/app-lib/com.test.testx86tabletcrash-1/libmapbox-gl.so
I/DEBUG:          75257a28  75257a48  [stack:3738]
I/DEBUG:          75257a2c  7819eca0  
I/DEBUG:          75257a30  781975c0  
I/DEBUG:          75257a34  76241fa8  /data/app-lib/com.test.testx86tabletcrash-1/libmapbox-gl.so
I/DEBUG:          75257a38  75257a68  [stack:3738]
I/DEBUG:          75257a3c  760272f3  /data/app-lib/com.test.testx86tabletcrash-1/libmapbox-gl.so
```