### PR TITLE
Rollback to System.loadLibrary to load native library.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -218,24 +218,6 @@ License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox GL uses portions of SoLoader.  
-URL: [https://github.com/facebook/soloader](https://github.com/facebook/soloader)  
-License: [Apache-2](https://github.com/facebook/soloader/blob/master/LICENSE)
-
-===========================================================================
-
-Mapbox GL uses portions of SoLoader.  
-URL: [https://github.com/facebook/soloader](https://github.com/facebook/soloader)  
-License: [Apache-2](https://github.com/facebook/soloader/blob/master/LICENSE)
-
-===========================================================================
-
-Mapbox GL uses portions of SoLoader.  
-URL: [https://github.com/facebook/soloader](https://github.com/facebook/soloader)  
-License: [Apache-2](https://github.com/facebook/soloader/blob/master/LICENSE)
-
-===========================================================================
-
 Mapbox GL uses portions of VersionedParcelable and friends.  
 URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)

--- a/MapboxGLAndroidSDK/build.gradle
+++ b/MapboxGLAndroidSDK/build.gradle
@@ -13,7 +13,6 @@ dependencies {
     implementation dependenciesList.supportAnnotations
     implementation dependenciesList.supportFragmentV4
     implementation dependenciesList.okhttp3
-    implementation dependenciesList.soLoader
     testImplementation dependenciesList.junit
     testImplementation dependenciesList.mockito
     testImplementation dependenciesList.mockk

--- a/MapboxGLAndroidSDK/proguard-rules.pro
+++ b/MapboxGLAndroidSDK/proguard-rules.pro
@@ -42,9 +42,3 @@
 # a large amount of users combine it with our SDK
 # we aren't able to provide a proguard config in that project (jar vs aar)
 -dontwarn com.sun.xml.internal.ws.spi.db.*
-
-# config for SoLoader https://github.com/mapbox/mapbox-gl-native-android/issues/60,
-# https://github.com/facebook/SoLoader/blob/master/java/com/facebook/soloader/soloader.pro
--keep class com.facebook.soloader.SysUtil$LollipopSysdeps {
-    public <methods>;
-}

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/LibraryLoader.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/LibraryLoader.java
@@ -5,7 +5,7 @@ import com.mapbox.mapboxsdk.log.Logger;
 /**
  * Loads the mapbox-gl shared library
  * <p>
- * By default uses SoLoader from https://github.com/facebook/SoLoader
+ * By default uses System.loadLibrary
  * use {@link #setLibraryLoader(LibraryLoader)} to provide an alternative library loading hook.
  * </p>
  */

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/module/loader/LibraryLoaderProviderImpl.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/module/loader/LibraryLoaderProviderImpl.java
@@ -2,16 +2,10 @@ package com.mapbox.mapboxsdk.module.loader;
 
 import com.mapbox.mapboxsdk.LibraryLoader;
 import com.mapbox.mapboxsdk.LibraryLoaderProvider;
-import com.mapbox.mapboxsdk.Mapbox;
-import com.mapbox.mapboxsdk.exceptions.MapboxConfigurationException;
-
-import static com.facebook.soloader.SoLoader.init;
-import static com.facebook.soloader.SoLoader.loadLibrary;
 
 /**
  * Concrete implementation of a native library loader.
  * <p>
- * Uses SoLoader from https://github.com/facebook/SoLoader.
  * </p>
  */
 public class LibraryLoaderProviderImpl implements LibraryLoaderProvider {
@@ -23,26 +17,16 @@ public class LibraryLoaderProviderImpl implements LibraryLoaderProvider {
    */
   @Override
   public LibraryLoader getDefaultLibraryLoader() {
-    return new SoLibraryLoader();
+    return new SystemLibraryLoader();
   }
 
   /**
-   * Concrete implementation of a LibraryLoader using SoLoader.
+   * Concrete implementation of a LibraryLoader using System.loadLibrary.
    */
-  private static class SoLibraryLoader extends LibraryLoader {
-
-    private static final String TAG = "SoLibraryLoader";
-
+  private static class SystemLibraryLoader extends LibraryLoader {
     @Override
     public void load(String name) {
-      try {
-        // nativeExopackage = false, https://buck.build/article/exopackage.html
-        init(Mapbox.getApplicationContext(), false);
-        loadLibrary(name);
-      } catch (MapboxConfigurationException exception) {
-        //Rollback to System.loadLibrary if SoLoader failed to load library.
-        System.loadLibrary(name);
-      }
+      System.loadLibrary(name);
     }
   }
 }

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/module/loader/LibraryLoaderProviderImpl.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/module/loader/LibraryLoaderProviderImpl.java
@@ -4,7 +4,6 @@ import com.mapbox.mapboxsdk.LibraryLoader;
 import com.mapbox.mapboxsdk.LibraryLoaderProvider;
 import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.exceptions.MapboxConfigurationException;
-import com.mapbox.mapboxsdk.log.Logger;
 
 import static com.facebook.soloader.SoLoader.init;
 import static com.facebook.soloader.SoLoader.loadLibrary;
@@ -41,9 +40,8 @@ public class LibraryLoaderProviderImpl implements LibraryLoaderProvider {
         init(Mapbox.getApplicationContext(), false);
         loadLibrary(name);
       } catch (MapboxConfigurationException exception) {
-        Logger.e(TAG, "Couldn't load so file with relinker, application context missing, "
-          + "call Mapbox.getInstance(Context context, String accessToken) first");
-        throw new UnsatisfiedLinkError(exception.getMessage());
+        //Rollback to System.loadLibrary if SoLoader failed to load library.
+        System.loadLibrary(name);
       }
     }
   }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -35,7 +35,6 @@ ext {
             androidPublish  : '3.6.2',
             lint            : '26.4.2',
             gms             : '16.0.0',
-            soLoader        : '0.8.0',
             jacoco          : '0.8.4',
             appcenter       : '1.4',
             ktlint          : '0.34.0',
@@ -74,7 +73,6 @@ ext {
             okhttp3                : "com.squareup.okhttp3:okhttp:${versions.okhttp}",
             leakCanaryDebug        : "com.squareup.leakcanary:leakcanary-android:${versions.leakCanary}",
             leakCanaryRelease      : "com.squareup.leakcanary:leakcanary-android-no-op:${versions.leakCanary}",
-            soLoader               : "com.facebook.soloader:soloader:${versions.soLoader}",
 
             kotlinLib              : "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}",
             kotlinPlugin           : "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}",


### PR DESCRIPTION
`<changelog>Fix loading library failure by rollbacking to System.loadLibrary if SoLoader failed to load the library.
</changelog>`
Resolves #367 