### PR TITLE
Fix text cut off when halo text width is applied

### DIFF
--- a/MapboxGLAndroidSDK/src/cpp/text/local_glyph_rasterizer.cpp
+++ b/MapboxGLAndroidSDK/src/cpp/text/local_glyph_rasterizer.cpp
@@ -111,8 +111,8 @@ Glyph LocalGlyphRasterizer::rasterizeGlyph(const FontStack& fontStack, GlyphID g
 
     fixedMetrics.metrics.width = size.width;
     fixedMetrics.metrics.height = size.height;
-    fixedMetrics.metrics.left = 3;
-    fixedMetrics.metrics.top = -10;
+    fixedMetrics.metrics.left = -2;
+    fixedMetrics.metrics.top = -5;
     fixedMetrics.metrics.advance = 24;
 
     PremultipliedImage rgbaBitmap = impl->drawGlyphBitmap(fontStack, glyphID);

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/text/LocalGlyphRasterizer.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/text/LocalGlyphRasterizer.java
@@ -31,7 +31,7 @@ public class LocalGlyphRasterizer {
 
     paint = new Paint();
     paint.setAntiAlias(true);
-    paint.setTextSize(24);
+    paint.setTextSize(22);
 
     canvas = new Canvas();
     canvas.setBitmap(bitmap);

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/text/LocalGlyphRasterizer.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/text/LocalGlyphRasterizer.java
@@ -31,7 +31,7 @@ public class LocalGlyphRasterizer {
 
     paint = new Paint();
     paint.setAntiAlias(true);
-    paint.setTextSize(22);
+    paint.setTextSize(24);
 
     canvas = new Canvas();
     canvas.setBitmap(bitmap);
@@ -52,7 +52,7 @@ public class LocalGlyphRasterizer {
   protected Bitmap drawGlyphBitmap(String fontFamily, boolean bold, char glyphID) {
     paint.setTypeface(Typeface.create(fontFamily, bold ? Typeface.BOLD : Typeface.NORMAL));
     canvas.drawColor(Color.WHITE);
-    canvas.drawText(String.valueOf(glyphID), 0, 20, paint);
+    canvas.drawText(String.valueOf(glyphID), 5, 25, paint);
     return bitmap;
   }
 }


### PR DESCRIPTION
`<changelog>Fix the issue that top of the text is cut off when halo text width is applied.</changelog>`


