### PR TITLE
Fix getFilter with distance expression crash.

### DIFF
--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
@@ -9,6 +9,10 @@ import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.mapbox.geojson.GeoJson;
+import com.mapbox.geojson.LineString;
+import com.mapbox.geojson.MultiLineString;
+import com.mapbox.geojson.MultiPoint;
+import com.mapbox.geojson.Point;
 import com.mapbox.geojson.Polygon;
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
 import com.mapbox.mapboxsdk.style.layers.PropertyValue;
@@ -4767,6 +4771,18 @@ public class Expression {
       final List<Expression> arguments = new ArrayList<>();
       if (operator.equals("within")) {
         return within(Polygon.fromJson(jsonArray.get(1).toString()));
+      } else if (operator.equals("distance")) {
+        final String type = jsonArray.get(1).getAsJsonObject().get("type").getAsString();
+        String json = jsonArray.get(1).toString();
+        if ("Point".equals(type)) {
+          return distance(Point.fromJson(json));
+        } else if ("LineString".equals(type)) {
+          return distance(LineString.fromJson(json));
+        } else if ("MultiPoint".equals(type)) {
+          return distance(MultiPoint.fromJson(json));
+        } else {
+          return distance(MultiLineString.fromJson(json));
+        }
       }
       for (int i = 1; i < jsonArray.size(); i++) {
         JsonElement jsonElement = jsonArray.get(i);

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
@@ -15,6 +15,7 @@ import com.mapbox.geojson.MultiPoint;
 import com.mapbox.geojson.MultiPolygon;
 import com.mapbox.geojson.Point;
 import com.mapbox.geojson.Polygon;
+import com.mapbox.geojson.gson.GeometryGeoJson;
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
 import com.mapbox.mapboxsdk.style.layers.PropertyValue;
 
@@ -4774,21 +4775,7 @@ public class Expression {
       if (operator.equals("within")) {
         return within(Polygon.fromJson(jsonArray.get(1).toString()));
       } else if (operator.equals("distance")) {
-        final String type = jsonArray.get(1).getAsJsonObject().get("type").getAsString();
-        String json = jsonArray.get(1).toString();
-        if ("Point".equals(type)) {
-          return distance(Point.fromJson(json));
-        } else if ("LineString".equals(type)) {
-          return distance(LineString.fromJson(json));
-        } else if ("MultiPoint".equals(type)) {
-          return distance(MultiPoint.fromJson(json));
-        } else if ("Polygon".equals(type)) {
-          return distance(Polygon.fromJson(json));
-        } else if ("MultiPolygon".equals(type)) {
-          return distance(MultiPolygon.fromJson(json));
-        } else {
-          return distance(MultiLineString.fromJson(json));
-        }
+        return distance(GeometryGeoJson.fromJson(jsonArray.get(1).toString()));
       }
       for (int i = 1; i < jsonArray.size(); i++) {
         JsonElement jsonElement = jsonArray.get(i);

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/expressions/Expression.java
@@ -12,6 +12,7 @@ import com.mapbox.geojson.GeoJson;
 import com.mapbox.geojson.LineString;
 import com.mapbox.geojson.MultiLineString;
 import com.mapbox.geojson.MultiPoint;
+import com.mapbox.geojson.MultiPolygon;
 import com.mapbox.geojson.Point;
 import com.mapbox.geojson.Polygon;
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
@@ -1587,7 +1588,8 @@ public class Expression {
    * Currently supports `Point`, `MultiPoint`, `LineString`, `MultiLineString` geometry types.
    *
    * @param geoJson the target feature geoJson.
-   *                Currently supports `Point`, `MultiPoint`, `LineString`, `MultiLineString` geometry types
+   *                Currently supports `Point`, `MultiPoint`, `LineString`, `MultiLineString`, `Polygon`, `MultiPolygon`
+   *                geometry types
    * @return the distance in the unit "meters".
    * @see <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#expressions-distance">Style specification</a>
    */
@@ -4780,6 +4782,10 @@ public class Expression {
           return distance(LineString.fromJson(json));
         } else if ("MultiPoint".equals(type)) {
           return distance(MultiPoint.fromJson(json));
+        } else if ("Polygon".equals(type)) {
+          return distance(Polygon.fromJson(json));
+        } else if ("MultiPolygon".equals(type)) {
+          return distance(MultiPolygon.fromJson(json));
         } else {
           return distance(MultiLineString.fromJson(json));
         }

--- a/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/BackgroundLayerTest.java
+++ b/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/BackgroundLayerTest.java
@@ -9,6 +9,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.mapbox.geojson.LineString;
 import com.mapbox.geojson.MultiLineString;
 import com.mapbox.geojson.MultiPoint;
+import com.mapbox.geojson.MultiPolygon;
 import com.mapbox.geojson.Point;
 import com.mapbox.geojson.Polygon;
 import com.mapbox.mapboxsdk.maps.BaseLayerTest;

--- a/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/BackgroundLayerTest.java
+++ b/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/BackgroundLayerTest.java
@@ -6,6 +6,11 @@ import android.graphics.Color;
 import androidx.test.annotation.UiThreadTest;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import com.mapbox.geojson.LineString;
+import com.mapbox.geojson.MultiLineString;
+import com.mapbox.geojson.MultiPoint;
+import com.mapbox.geojson.Point;
+import com.mapbox.geojson.Polygon;
 import com.mapbox.mapboxsdk.maps.BaseLayerTest;
 import org.junit.Before;
 import timber.log.Timber;
@@ -22,6 +27,9 @@ import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
 import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Basic smoke tests for BackgroundLayer
@@ -30,6 +38,19 @@ import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
 public class BackgroundLayerTest extends BaseLayerTest {
 
   private BackgroundLayer layer;
+  private final List<Point> pointsList = new ArrayList<Point>() {
+    {
+      add(Point.fromLngLat(55.30122473231012, 25.26476622289597));
+      add(Point.fromLngLat(55.29743486255916, 25.25827212207261));
+      add(Point.fromLngLat(55.28978863411328, 25.251356725509737));
+      add(Point.fromLngLat(55.300027931336984, 25.246425506635504));
+      add(Point.fromLngLat(55.307474692951274, 25.244200378933655));
+      add(Point.fromLngLat(55.31212891895635, 25.256408010450187));
+      add(Point.fromLngLat(55.30774064871093, 25.26266169122738));
+      add(Point.fromLngLat(55.301357710197806, 25.264946609615492));
+      add(Point.fromLngLat(55.30122473231012, 25.26476622289597));
+    }
+  };
 
   @Before
   @UiThreadTest

--- a/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/CircleLayerTest.java
+++ b/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/CircleLayerTest.java
@@ -6,6 +6,11 @@ import android.graphics.Color;
 import androidx.test.annotation.UiThreadTest;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import com.mapbox.geojson.LineString;
+import com.mapbox.geojson.MultiLineString;
+import com.mapbox.geojson.MultiPoint;
+import com.mapbox.geojson.Point;
+import com.mapbox.geojson.Polygon;
 import com.mapbox.mapboxsdk.maps.BaseLayerTest;
 import org.junit.Before;
 import timber.log.Timber;
@@ -22,6 +27,9 @@ import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
 import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Basic smoke tests for CircleLayer
@@ -30,6 +38,19 @@ import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
 public class CircleLayerTest extends BaseLayerTest {
 
   private CircleLayer layer;
+  private final List<Point> pointsList = new ArrayList<Point>() {
+    {
+      add(Point.fromLngLat(55.30122473231012, 25.26476622289597));
+      add(Point.fromLngLat(55.29743486255916, 25.25827212207261));
+      add(Point.fromLngLat(55.28978863411328, 25.251356725509737));
+      add(Point.fromLngLat(55.300027931336984, 25.246425506635504));
+      add(Point.fromLngLat(55.307474692951274, 25.244200378933655));
+      add(Point.fromLngLat(55.31212891895635, 25.256408010450187));
+      add(Point.fromLngLat(55.30774064871093, 25.26266169122738));
+      add(Point.fromLngLat(55.301357710197806, 25.264946609615492));
+      add(Point.fromLngLat(55.30122473231012, 25.26476622289597));
+    }
+  };
 
   @Before
   @UiThreadTest
@@ -97,6 +118,49 @@ public class CircleLayerTest extends BaseLayerTest {
     assertEquals(layer.getFilter().toString(), filter.toString());
   }
 
+  @Test
+  @UiThreadTest
+  public void testFilterDistance() {
+    Timber.i("FilterDistance");
+    assertNotNull(layer);
+
+    // Get initial
+    assertEquals(layer.getFilter(), null);
+
+    // distance with Point
+    Expression filter = lt(distance(Point.fromLngLat(1.0, 1.0)), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with LineString
+    filter = lt(distance(LineString.fromLngLats(pointsList)), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with MultiPoint
+    filter = lt(distance(MultiPoint.fromLngLats(pointsList)), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with MultiPoint
+    filter = lt(distance(MultiLineString.fromLngLats(Collections.singletonList(pointsList))), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+  }
+
+  @Test
+  @UiThreadTest
+  public void testFilterWithin() {
+    Timber.i("FilterWithin");
+    assertNotNull(layer);
+
+    // Get initial
+    assertEquals(layer.getFilter(), null);
+
+    Expression filter = within(Polygon.fromLngLats(Collections.singletonList(pointsList)));
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+  }
 
 
   @Test

--- a/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/CircleLayerTest.java
+++ b/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/CircleLayerTest.java
@@ -9,6 +9,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.mapbox.geojson.LineString;
 import com.mapbox.geojson.MultiLineString;
 import com.mapbox.geojson.MultiPoint;
+import com.mapbox.geojson.MultiPolygon;
 import com.mapbox.geojson.Point;
 import com.mapbox.geojson.Polygon;
 import com.mapbox.mapboxsdk.maps.BaseLayerTest;
@@ -144,6 +145,17 @@ public class CircleLayerTest extends BaseLayerTest {
 
     // distance with MultiPoint
     filter = lt(distance(MultiLineString.fromLngLats(Collections.singletonList(pointsList))), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with Polygon
+    filter = lt(distance(Polygon.fromLngLats(Collections.singletonList(pointsList))), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with MultiPolygon
+    filter = lt(distance(MultiPolygon.fromLngLats(Collections
+      .singletonList(Collections.singletonList(pointsList)))), 50);
     layer.setFilter(filter);
     assertEquals(layer.getFilter().toString(), filter.toString());
   }

--- a/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillExtrusionLayerTest.java
+++ b/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillExtrusionLayerTest.java
@@ -6,6 +6,11 @@ import android.graphics.Color;
 import androidx.test.annotation.UiThreadTest;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import com.mapbox.geojson.LineString;
+import com.mapbox.geojson.MultiLineString;
+import com.mapbox.geojson.MultiPoint;
+import com.mapbox.geojson.Point;
+import com.mapbox.geojson.Polygon;
 import com.mapbox.mapboxsdk.maps.BaseLayerTest;
 import org.junit.Before;
 import timber.log.Timber;
@@ -22,6 +27,9 @@ import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
 import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Basic smoke tests for FillExtrusionLayer
@@ -30,6 +38,19 @@ import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
 public class FillExtrusionLayerTest extends BaseLayerTest {
 
   private FillExtrusionLayer layer;
+  private final List<Point> pointsList = new ArrayList<Point>() {
+    {
+      add(Point.fromLngLat(55.30122473231012, 25.26476622289597));
+      add(Point.fromLngLat(55.29743486255916, 25.25827212207261));
+      add(Point.fromLngLat(55.28978863411328, 25.251356725509737));
+      add(Point.fromLngLat(55.300027931336984, 25.246425506635504));
+      add(Point.fromLngLat(55.307474692951274, 25.244200378933655));
+      add(Point.fromLngLat(55.31212891895635, 25.256408010450187));
+      add(Point.fromLngLat(55.30774064871093, 25.26266169122738));
+      add(Point.fromLngLat(55.301357710197806, 25.264946609615492));
+      add(Point.fromLngLat(55.30122473231012, 25.26476622289597));
+    }
+  };
 
   @Before
   @UiThreadTest
@@ -97,6 +118,49 @@ public class FillExtrusionLayerTest extends BaseLayerTest {
     assertEquals(layer.getFilter().toString(), filter.toString());
   }
 
+  @Test
+  @UiThreadTest
+  public void testFilterDistance() {
+    Timber.i("FilterDistance");
+    assertNotNull(layer);
+
+    // Get initial
+    assertEquals(layer.getFilter(), null);
+
+    // distance with Point
+    Expression filter = lt(distance(Point.fromLngLat(1.0, 1.0)), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with LineString
+    filter = lt(distance(LineString.fromLngLats(pointsList)), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with MultiPoint
+    filter = lt(distance(MultiPoint.fromLngLats(pointsList)), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with MultiPoint
+    filter = lt(distance(MultiLineString.fromLngLats(Collections.singletonList(pointsList))), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+  }
+
+  @Test
+  @UiThreadTest
+  public void testFilterWithin() {
+    Timber.i("FilterWithin");
+    assertNotNull(layer);
+
+    // Get initial
+    assertEquals(layer.getFilter(), null);
+
+    Expression filter = within(Polygon.fromLngLats(Collections.singletonList(pointsList)));
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+  }
 
 
   @Test

--- a/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillExtrusionLayerTest.java
+++ b/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillExtrusionLayerTest.java
@@ -9,6 +9,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.mapbox.geojson.LineString;
 import com.mapbox.geojson.MultiLineString;
 import com.mapbox.geojson.MultiPoint;
+import com.mapbox.geojson.MultiPolygon;
 import com.mapbox.geojson.Point;
 import com.mapbox.geojson.Polygon;
 import com.mapbox.mapboxsdk.maps.BaseLayerTest;
@@ -144,6 +145,17 @@ public class FillExtrusionLayerTest extends BaseLayerTest {
 
     // distance with MultiPoint
     filter = lt(distance(MultiLineString.fromLngLats(Collections.singletonList(pointsList))), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with Polygon
+    filter = lt(distance(Polygon.fromLngLats(Collections.singletonList(pointsList))), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with MultiPolygon
+    filter = lt(distance(MultiPolygon.fromLngLats(Collections
+      .singletonList(Collections.singletonList(pointsList)))), 50);
     layer.setFilter(filter);
     assertEquals(layer.getFilter().toString(), filter.toString());
   }

--- a/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillLayerTest.java
+++ b/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillLayerTest.java
@@ -9,6 +9,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.mapbox.geojson.LineString;
 import com.mapbox.geojson.MultiLineString;
 import com.mapbox.geojson.MultiPoint;
+import com.mapbox.geojson.MultiPolygon;
 import com.mapbox.geojson.Point;
 import com.mapbox.geojson.Polygon;
 import com.mapbox.mapboxsdk.maps.BaseLayerTest;
@@ -144,6 +145,17 @@ public class FillLayerTest extends BaseLayerTest {
 
     // distance with MultiPoint
     filter = lt(distance(MultiLineString.fromLngLats(Collections.singletonList(pointsList))), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with Polygon
+    filter = lt(distance(Polygon.fromLngLats(Collections.singletonList(pointsList))), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with MultiPolygon
+    filter = lt(distance(MultiPolygon.fromLngLats(Collections
+      .singletonList(Collections.singletonList(pointsList)))), 50);
     layer.setFilter(filter);
     assertEquals(layer.getFilter().toString(), filter.toString());
   }

--- a/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillLayerTest.java
+++ b/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillLayerTest.java
@@ -6,6 +6,11 @@ import android.graphics.Color;
 import androidx.test.annotation.UiThreadTest;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import com.mapbox.geojson.LineString;
+import com.mapbox.geojson.MultiLineString;
+import com.mapbox.geojson.MultiPoint;
+import com.mapbox.geojson.Point;
+import com.mapbox.geojson.Polygon;
 import com.mapbox.mapboxsdk.maps.BaseLayerTest;
 import org.junit.Before;
 import timber.log.Timber;
@@ -22,6 +27,9 @@ import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
 import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Basic smoke tests for FillLayer
@@ -30,6 +38,19 @@ import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
 public class FillLayerTest extends BaseLayerTest {
 
   private FillLayer layer;
+  private final List<Point> pointsList = new ArrayList<Point>() {
+    {
+      add(Point.fromLngLat(55.30122473231012, 25.26476622289597));
+      add(Point.fromLngLat(55.29743486255916, 25.25827212207261));
+      add(Point.fromLngLat(55.28978863411328, 25.251356725509737));
+      add(Point.fromLngLat(55.300027931336984, 25.246425506635504));
+      add(Point.fromLngLat(55.307474692951274, 25.244200378933655));
+      add(Point.fromLngLat(55.31212891895635, 25.256408010450187));
+      add(Point.fromLngLat(55.30774064871093, 25.26266169122738));
+      add(Point.fromLngLat(55.301357710197806, 25.264946609615492));
+      add(Point.fromLngLat(55.30122473231012, 25.26476622289597));
+    }
+  };
 
   @Before
   @UiThreadTest
@@ -97,6 +118,49 @@ public class FillLayerTest extends BaseLayerTest {
     assertEquals(layer.getFilter().toString(), filter.toString());
   }
 
+  @Test
+  @UiThreadTest
+  public void testFilterDistance() {
+    Timber.i("FilterDistance");
+    assertNotNull(layer);
+
+    // Get initial
+    assertEquals(layer.getFilter(), null);
+
+    // distance with Point
+    Expression filter = lt(distance(Point.fromLngLat(1.0, 1.0)), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with LineString
+    filter = lt(distance(LineString.fromLngLats(pointsList)), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with MultiPoint
+    filter = lt(distance(MultiPoint.fromLngLats(pointsList)), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with MultiPoint
+    filter = lt(distance(MultiLineString.fromLngLats(Collections.singletonList(pointsList))), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+  }
+
+  @Test
+  @UiThreadTest
+  public void testFilterWithin() {
+    Timber.i("FilterWithin");
+    assertNotNull(layer);
+
+    // Get initial
+    assertEquals(layer.getFilter(), null);
+
+    Expression filter = within(Polygon.fromLngLats(Collections.singletonList(pointsList)));
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+  }
 
 
   @Test

--- a/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/HeatmapLayerTest.java
+++ b/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/HeatmapLayerTest.java
@@ -9,6 +9,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.mapbox.geojson.LineString;
 import com.mapbox.geojson.MultiLineString;
 import com.mapbox.geojson.MultiPoint;
+import com.mapbox.geojson.MultiPolygon;
 import com.mapbox.geojson.Point;
 import com.mapbox.geojson.Polygon;
 import com.mapbox.mapboxsdk.maps.BaseLayerTest;
@@ -144,6 +145,17 @@ public class HeatmapLayerTest extends BaseLayerTest {
 
     // distance with MultiPoint
     filter = lt(distance(MultiLineString.fromLngLats(Collections.singletonList(pointsList))), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with Polygon
+    filter = lt(distance(Polygon.fromLngLats(Collections.singletonList(pointsList))), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with MultiPolygon
+    filter = lt(distance(MultiPolygon.fromLngLats(Collections
+      .singletonList(Collections.singletonList(pointsList)))), 50);
     layer.setFilter(filter);
     assertEquals(layer.getFilter().toString(), filter.toString());
   }

--- a/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/HeatmapLayerTest.java
+++ b/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/HeatmapLayerTest.java
@@ -6,6 +6,11 @@ import android.graphics.Color;
 import androidx.test.annotation.UiThreadTest;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import com.mapbox.geojson.LineString;
+import com.mapbox.geojson.MultiLineString;
+import com.mapbox.geojson.MultiPoint;
+import com.mapbox.geojson.Point;
+import com.mapbox.geojson.Polygon;
 import com.mapbox.mapboxsdk.maps.BaseLayerTest;
 import org.junit.Before;
 import timber.log.Timber;
@@ -22,6 +27,9 @@ import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
 import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Basic smoke tests for HeatmapLayer
@@ -30,6 +38,19 @@ import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
 public class HeatmapLayerTest extends BaseLayerTest {
 
   private HeatmapLayer layer;
+  private final List<Point> pointsList = new ArrayList<Point>() {
+    {
+      add(Point.fromLngLat(55.30122473231012, 25.26476622289597));
+      add(Point.fromLngLat(55.29743486255916, 25.25827212207261));
+      add(Point.fromLngLat(55.28978863411328, 25.251356725509737));
+      add(Point.fromLngLat(55.300027931336984, 25.246425506635504));
+      add(Point.fromLngLat(55.307474692951274, 25.244200378933655));
+      add(Point.fromLngLat(55.31212891895635, 25.256408010450187));
+      add(Point.fromLngLat(55.30774064871093, 25.26266169122738));
+      add(Point.fromLngLat(55.301357710197806, 25.264946609615492));
+      add(Point.fromLngLat(55.30122473231012, 25.26476622289597));
+    }
+  };
 
   @Before
   @UiThreadTest
@@ -97,6 +118,49 @@ public class HeatmapLayerTest extends BaseLayerTest {
     assertEquals(layer.getFilter().toString(), filter.toString());
   }
 
+  @Test
+  @UiThreadTest
+  public void testFilterDistance() {
+    Timber.i("FilterDistance");
+    assertNotNull(layer);
+
+    // Get initial
+    assertEquals(layer.getFilter(), null);
+
+    // distance with Point
+    Expression filter = lt(distance(Point.fromLngLat(1.0, 1.0)), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with LineString
+    filter = lt(distance(LineString.fromLngLats(pointsList)), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with MultiPoint
+    filter = lt(distance(MultiPoint.fromLngLats(pointsList)), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with MultiPoint
+    filter = lt(distance(MultiLineString.fromLngLats(Collections.singletonList(pointsList))), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+  }
+
+  @Test
+  @UiThreadTest
+  public void testFilterWithin() {
+    Timber.i("FilterWithin");
+    assertNotNull(layer);
+
+    // Get initial
+    assertEquals(layer.getFilter(), null);
+
+    Expression filter = within(Polygon.fromLngLats(Collections.singletonList(pointsList)));
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+  }
 
 
   @Test

--- a/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/HillshadeLayerTest.java
+++ b/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/HillshadeLayerTest.java
@@ -9,6 +9,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.mapbox.geojson.LineString;
 import com.mapbox.geojson.MultiLineString;
 import com.mapbox.geojson.MultiPoint;
+import com.mapbox.geojson.MultiPolygon;
 import com.mapbox.geojson.Point;
 import com.mapbox.geojson.Polygon;
 import com.mapbox.mapboxsdk.maps.BaseLayerTest;

--- a/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/HillshadeLayerTest.java
+++ b/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/HillshadeLayerTest.java
@@ -6,6 +6,11 @@ import android.graphics.Color;
 import androidx.test.annotation.UiThreadTest;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import com.mapbox.geojson.LineString;
+import com.mapbox.geojson.MultiLineString;
+import com.mapbox.geojson.MultiPoint;
+import com.mapbox.geojson.Point;
+import com.mapbox.geojson.Polygon;
 import com.mapbox.mapboxsdk.maps.BaseLayerTest;
 import org.junit.Before;
 import timber.log.Timber;
@@ -22,6 +27,9 @@ import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
 import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Basic smoke tests for HillshadeLayer
@@ -30,6 +38,19 @@ import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
 public class HillshadeLayerTest extends BaseLayerTest {
 
   private HillshadeLayer layer;
+  private final List<Point> pointsList = new ArrayList<Point>() {
+    {
+      add(Point.fromLngLat(55.30122473231012, 25.26476622289597));
+      add(Point.fromLngLat(55.29743486255916, 25.25827212207261));
+      add(Point.fromLngLat(55.28978863411328, 25.251356725509737));
+      add(Point.fromLngLat(55.300027931336984, 25.246425506635504));
+      add(Point.fromLngLat(55.307474692951274, 25.244200378933655));
+      add(Point.fromLngLat(55.31212891895635, 25.256408010450187));
+      add(Point.fromLngLat(55.30774064871093, 25.26266169122738));
+      add(Point.fromLngLat(55.301357710197806, 25.264946609615492));
+      add(Point.fromLngLat(55.30122473231012, 25.26476622289597));
+    }
+  };
 
   @Before
   @UiThreadTest

--- a/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/LineLayerTest.java
+++ b/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/LineLayerTest.java
@@ -6,6 +6,11 @@ import android.graphics.Color;
 import androidx.test.annotation.UiThreadTest;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import com.mapbox.geojson.LineString;
+import com.mapbox.geojson.MultiLineString;
+import com.mapbox.geojson.MultiPoint;
+import com.mapbox.geojson.Point;
+import com.mapbox.geojson.Polygon;
 import com.mapbox.mapboxsdk.maps.BaseLayerTest;
 import org.junit.Before;
 import timber.log.Timber;
@@ -22,6 +27,9 @@ import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
 import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Basic smoke tests for LineLayer
@@ -30,6 +38,19 @@ import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
 public class LineLayerTest extends BaseLayerTest {
 
   private LineLayer layer;
+  private final List<Point> pointsList = new ArrayList<Point>() {
+    {
+      add(Point.fromLngLat(55.30122473231012, 25.26476622289597));
+      add(Point.fromLngLat(55.29743486255916, 25.25827212207261));
+      add(Point.fromLngLat(55.28978863411328, 25.251356725509737));
+      add(Point.fromLngLat(55.300027931336984, 25.246425506635504));
+      add(Point.fromLngLat(55.307474692951274, 25.244200378933655));
+      add(Point.fromLngLat(55.31212891895635, 25.256408010450187));
+      add(Point.fromLngLat(55.30774064871093, 25.26266169122738));
+      add(Point.fromLngLat(55.301357710197806, 25.264946609615492));
+      add(Point.fromLngLat(55.30122473231012, 25.26476622289597));
+    }
+  };
 
   @Before
   @UiThreadTest
@@ -97,6 +118,49 @@ public class LineLayerTest extends BaseLayerTest {
     assertEquals(layer.getFilter().toString(), filter.toString());
   }
 
+  @Test
+  @UiThreadTest
+  public void testFilterDistance() {
+    Timber.i("FilterDistance");
+    assertNotNull(layer);
+
+    // Get initial
+    assertEquals(layer.getFilter(), null);
+
+    // distance with Point
+    Expression filter = lt(distance(Point.fromLngLat(1.0, 1.0)), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with LineString
+    filter = lt(distance(LineString.fromLngLats(pointsList)), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with MultiPoint
+    filter = lt(distance(MultiPoint.fromLngLats(pointsList)), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with MultiPoint
+    filter = lt(distance(MultiLineString.fromLngLats(Collections.singletonList(pointsList))), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+  }
+
+  @Test
+  @UiThreadTest
+  public void testFilterWithin() {
+    Timber.i("FilterWithin");
+    assertNotNull(layer);
+
+    // Get initial
+    assertEquals(layer.getFilter(), null);
+
+    Expression filter = within(Polygon.fromLngLats(Collections.singletonList(pointsList)));
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+  }
 
 
   @Test

--- a/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/LineLayerTest.java
+++ b/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/LineLayerTest.java
@@ -9,6 +9,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.mapbox.geojson.LineString;
 import com.mapbox.geojson.MultiLineString;
 import com.mapbox.geojson.MultiPoint;
+import com.mapbox.geojson.MultiPolygon;
 import com.mapbox.geojson.Point;
 import com.mapbox.geojson.Polygon;
 import com.mapbox.mapboxsdk.maps.BaseLayerTest;
@@ -144,6 +145,17 @@ public class LineLayerTest extends BaseLayerTest {
 
     // distance with MultiPoint
     filter = lt(distance(MultiLineString.fromLngLats(Collections.singletonList(pointsList))), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with Polygon
+    filter = lt(distance(Polygon.fromLngLats(Collections.singletonList(pointsList))), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with MultiPolygon
+    filter = lt(distance(MultiPolygon.fromLngLats(Collections
+      .singletonList(Collections.singletonList(pointsList)))), 50);
     layer.setFilter(filter);
     assertEquals(layer.getFilter().toString(), filter.toString());
   }

--- a/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/RasterLayerTest.java
+++ b/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/RasterLayerTest.java
@@ -9,6 +9,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.mapbox.geojson.LineString;
 import com.mapbox.geojson.MultiLineString;
 import com.mapbox.geojson.MultiPoint;
+import com.mapbox.geojson.MultiPolygon;
 import com.mapbox.geojson.Point;
 import com.mapbox.geojson.Polygon;
 import com.mapbox.mapboxsdk.maps.BaseLayerTest;

--- a/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/RasterLayerTest.java
+++ b/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/RasterLayerTest.java
@@ -6,6 +6,11 @@ import android.graphics.Color;
 import androidx.test.annotation.UiThreadTest;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import com.mapbox.geojson.LineString;
+import com.mapbox.geojson.MultiLineString;
+import com.mapbox.geojson.MultiPoint;
+import com.mapbox.geojson.Point;
+import com.mapbox.geojson.Polygon;
 import com.mapbox.mapboxsdk.maps.BaseLayerTest;
 import org.junit.Before;
 import timber.log.Timber;
@@ -22,6 +27,9 @@ import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
 import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Basic smoke tests for RasterLayer
@@ -30,6 +38,19 @@ import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
 public class RasterLayerTest extends BaseLayerTest {
 
   private RasterLayer layer;
+  private final List<Point> pointsList = new ArrayList<Point>() {
+    {
+      add(Point.fromLngLat(55.30122473231012, 25.26476622289597));
+      add(Point.fromLngLat(55.29743486255916, 25.25827212207261));
+      add(Point.fromLngLat(55.28978863411328, 25.251356725509737));
+      add(Point.fromLngLat(55.300027931336984, 25.246425506635504));
+      add(Point.fromLngLat(55.307474692951274, 25.244200378933655));
+      add(Point.fromLngLat(55.31212891895635, 25.256408010450187));
+      add(Point.fromLngLat(55.30774064871093, 25.26266169122738));
+      add(Point.fromLngLat(55.301357710197806, 25.264946609615492));
+      add(Point.fromLngLat(55.30122473231012, 25.26476622289597));
+    }
+  };
 
   @Before
   @UiThreadTest

--- a/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/SymbolLayerTest.java
+++ b/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/SymbolLayerTest.java
@@ -6,6 +6,11 @@ import android.graphics.Color;
 import androidx.test.annotation.UiThreadTest;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import com.mapbox.geojson.LineString;
+import com.mapbox.geojson.MultiLineString;
+import com.mapbox.geojson.MultiPoint;
+import com.mapbox.geojson.Point;
+import com.mapbox.geojson.Polygon;
 import com.mapbox.mapboxsdk.maps.BaseLayerTest;
 import org.junit.Before;
 import timber.log.Timber;
@@ -24,6 +29,9 @@ import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
 import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Basic smoke tests for SymbolLayer
@@ -32,6 +40,19 @@ import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
 public class SymbolLayerTest extends BaseLayerTest {
 
   private SymbolLayer layer;
+  private final List<Point> pointsList = new ArrayList<Point>() {
+    {
+      add(Point.fromLngLat(55.30122473231012, 25.26476622289597));
+      add(Point.fromLngLat(55.29743486255916, 25.25827212207261));
+      add(Point.fromLngLat(55.28978863411328, 25.251356725509737));
+      add(Point.fromLngLat(55.300027931336984, 25.246425506635504));
+      add(Point.fromLngLat(55.307474692951274, 25.244200378933655));
+      add(Point.fromLngLat(55.31212891895635, 25.256408010450187));
+      add(Point.fromLngLat(55.30774064871093, 25.26266169122738));
+      add(Point.fromLngLat(55.301357710197806, 25.264946609615492));
+      add(Point.fromLngLat(55.30122473231012, 25.26476622289597));
+    }
+  };
 
   @Before
   @UiThreadTest
@@ -99,6 +120,49 @@ public class SymbolLayerTest extends BaseLayerTest {
     assertEquals(layer.getFilter().toString(), filter.toString());
   }
 
+  @Test
+  @UiThreadTest
+  public void testFilterDistance() {
+    Timber.i("FilterDistance");
+    assertNotNull(layer);
+
+    // Get initial
+    assertEquals(layer.getFilter(), null);
+
+    // distance with Point
+    Expression filter = lt(distance(Point.fromLngLat(1.0, 1.0)), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with LineString
+    filter = lt(distance(LineString.fromLngLats(pointsList)), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with MultiPoint
+    filter = lt(distance(MultiPoint.fromLngLats(pointsList)), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with MultiPoint
+    filter = lt(distance(MultiLineString.fromLngLats(Collections.singletonList(pointsList))), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+  }
+
+  @Test
+  @UiThreadTest
+  public void testFilterWithin() {
+    Timber.i("FilterWithin");
+    assertNotNull(layer);
+
+    // Get initial
+    assertEquals(layer.getFilter(), null);
+
+    Expression filter = within(Polygon.fromLngLats(Collections.singletonList(pointsList)));
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+  }
 
 
   @Test

--- a/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/SymbolLayerTest.java
+++ b/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/SymbolLayerTest.java
@@ -9,6 +9,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.mapbox.geojson.LineString;
 import com.mapbox.geojson.MultiLineString;
 import com.mapbox.geojson.MultiPoint;
+import com.mapbox.geojson.MultiPolygon;
 import com.mapbox.geojson.Point;
 import com.mapbox.geojson.Polygon;
 import com.mapbox.mapboxsdk.maps.BaseLayerTest;
@@ -146,6 +147,17 @@ public class SymbolLayerTest extends BaseLayerTest {
 
     // distance with MultiPoint
     filter = lt(distance(MultiLineString.fromLngLats(Collections.singletonList(pointsList))), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with Polygon
+    filter = lt(distance(Polygon.fromLngLats(Collections.singletonList(pointsList))), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with MultiPolygon
+    filter = lt(distance(MultiPolygon.fromLngLats(Collections
+      .singletonList(Collections.singletonList(pointsList)))), 50);
     layer.setFilter(filter);
     assertEquals(layer.getFilter().toString(), filter.toString());
   }

--- a/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/layer.junit.ejs
+++ b/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/layer.junit.ejs
@@ -17,6 +17,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.mapbox.geojson.LineString;
 import com.mapbox.geojson.MultiLineString;
 import com.mapbox.geojson.MultiPoint;
+import com.mapbox.geojson.MultiPolygon;
 import com.mapbox.geojson.Point;
 import com.mapbox.geojson.Polygon;
 import com.mapbox.mapboxsdk.maps.BaseLayerTest;
@@ -169,6 +170,17 @@ public class <%- camelize(type) %>LayerTest extends BaseLayerTest {
 
     // distance with MultiPoint
     filter = lt(distance(MultiLineString.fromLngLats(Collections.singletonList(pointsList))), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with Polygon
+    filter = lt(distance(Polygon.fromLngLats(Collections.singletonList(pointsList))), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with MultiPolygon
+    filter = lt(distance(MultiPolygon.fromLngLats(Collections
+      .singletonList(Collections.singletonList(pointsList)))), 50);
     layer.setFilter(filter);
     assertEquals(layer.getFilter().toString(), filter.toString());
   }

--- a/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/layer.junit.ejs
+++ b/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/layer.junit.ejs
@@ -14,6 +14,11 @@ import android.graphics.Color;
 import androidx.test.annotation.UiThreadTest;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import com.mapbox.geojson.LineString;
+import com.mapbox.geojson.MultiLineString;
+import com.mapbox.geojson.MultiPoint;
+import com.mapbox.geojson.Point;
+import com.mapbox.geojson.Polygon;
 import com.mapbox.mapboxsdk.maps.BaseLayerTest;
 import org.junit.Before;
 import timber.log.Timber;
@@ -40,6 +45,9 @@ import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 <% } -%>
 
 import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Basic smoke tests for <%- camelize(type) %>Layer
@@ -48,6 +56,19 @@ import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
 public class <%- camelize(type) %>LayerTest extends BaseLayerTest {
 
   private <%- camelize(type) %>Layer layer;
+  private final List<Point> pointsList = new ArrayList<Point>() {
+    {
+      add(Point.fromLngLat(55.30122473231012, 25.26476622289597));
+      add(Point.fromLngLat(55.29743486255916, 25.25827212207261));
+      add(Point.fromLngLat(55.28978863411328, 25.251356725509737));
+      add(Point.fromLngLat(55.300027931336984, 25.246425506635504));
+      add(Point.fromLngLat(55.307474692951274, 25.244200378933655));
+      add(Point.fromLngLat(55.31212891895635, 25.256408010450187));
+      add(Point.fromLngLat(55.30774064871093, 25.26266169122738));
+      add(Point.fromLngLat(55.301357710197806, 25.264946609615492));
+      add(Point.fromLngLat(55.30122473231012, 25.26476622289597));
+    }
+  };
 
   @Before
   @UiThreadTest
@@ -122,6 +143,49 @@ public class <%- camelize(type) %>LayerTest extends BaseLayerTest {
     assertEquals(layer.getFilter().toString(), filter.toString());
   }
 
+  @Test
+  @UiThreadTest
+  public void testFilterDistance() {
+    Timber.i("FilterDistance");
+    assertNotNull(layer);
+
+    // Get initial
+    assertEquals(layer.getFilter(), null);
+
+    // distance with Point
+    Expression filter = lt(distance(Point.fromLngLat(1.0, 1.0)), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with LineString
+    filter = lt(distance(LineString.fromLngLats(pointsList)), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with MultiPoint
+    filter = lt(distance(MultiPoint.fromLngLats(pointsList)), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+
+    // distance with MultiPoint
+    filter = lt(distance(MultiLineString.fromLngLats(Collections.singletonList(pointsList))), 50);
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+  }
+
+  @Test
+  @UiThreadTest
+  public void testFilterWithin() {
+    Timber.i("FilterWithin");
+    assertNotNull(layer);
+
+    // Get initial
+    assertEquals(layer.getFilter(), null);
+
+    Expression filter = within(Polygon.fromLngLats(Collections.singletonList(pointsList)));
+    layer.setFilter(filter);
+    assertEquals(layer.getFilter().toString(), filter.toString());
+  }
 
 <% } -%>
 <% for (const property of properties) { -%>


### PR DESCRIPTION
`<changelog>Fixed a crash while Layer.getFilter() has expression distance content. </changelog>`

Update getFilter test for expression within and distance.
