### PR TITLE
CP: Reset AndroidRendererBackend properly

### DIFF
--- a/MapboxGLAndroidSDK/src/cpp/map_renderer.cpp
+++ b/MapboxGLAndroidSDK/src/cpp/map_renderer.cpp
@@ -122,6 +122,7 @@ void MapRenderer::requestSnapshot(SnapshotCallback callback) {
 
 void MapRenderer::resetRenderer() {
     renderer.reset();
+    backend.reset();
 }
 
 void MapRenderer::scheduleSnapshot(std::unique_ptr<SnapshotCallback> callback) {


### PR DESCRIPTION
Cherry-pick of #366:

`<changelog>Reset AndroidRendererBackend properly to prevent a crash during rotation on an Android 4.2.2 x86 tablet.</changelog>`