### PR TITLE
Update specialized location layer's docs

### DIFF
--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentActivationOptions.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentActivationOptions.java
@@ -127,8 +127,12 @@ public class LocationComponentActivationOptions {
    * but since it's not based on the runtime styling,
    * it's not fully compatible with the traditional implementation. The incompatibilities are:
    * <ul>
-   * <li> Constants like {@link LocationComponentConstants#FOREGROUND_LAYER}
+   * <li> Constants like {@link LocationComponentConstants#BACKGROUND_LAYER},
+   * {@link LocationComponentConstants#ACCURACY_LAYER}
    * or {@link LocationComponentConstants#LOCATION_SOURCE} are ignored.
+   * The only usable and valid for relative positioning layer ID is
+   * {@link LocationComponentConstants#FOREGROUND_LAYER}.
+   *
    * <li> All options that alter the image ID, like {@link LocationComponentOptions#foregroundName()}, are ignored.
    * Use {@link LocationComponentOptions#foregroundDrawable()} to alter the image rendered as the puck.
    * <li> The LocationComponent's pulsing effect. Any of the {@link LocationComponentOptions}'
@@ -244,8 +248,12 @@ public class LocationComponentActivationOptions {
      * but since it's not based on the runtime styling,
      * it's not fully compatible with the traditional implementation. The incompatibilities are:
      * <ul>
-     * <li> Constants like {@link LocationComponentConstants#FOREGROUND_LAYER}
+     * <li> Constants like {@link LocationComponentConstants#BACKGROUND_LAYER},
+     * {@link LocationComponentConstants#ACCURACY_LAYER}
      * or {@link LocationComponentConstants#LOCATION_SOURCE} are ignored.
+     * The only usable and valid for relative positioning layer ID is
+     * {@link LocationComponentConstants#FOREGROUND_LAYER}.
+     *
      * <li> All options that alter the image ID, like {@link LocationComponentOptions#foregroundName()}, are ignored.
      * Use {@link LocationComponentOptions#foregroundDrawable()} to alter the image rendered as the puck.
      * <li> The LocationComponent's pulsing effect. Any of the {@link LocationComponentOptions}'

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentConstants.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentConstants.java
@@ -63,7 +63,8 @@ public final class LocationComponentConstants {
   public static final String SHADOW_LAYER = "mapbox-location-shadow-layer";
 
   /**
-   * Layer ID of the location foreground icon.
+   * Layer ID of the location foreground icon or the only runtime layer added if
+   * {@link LocationComponentActivationOptions#useSpecializedLocationLayer()} is used.
    */
   public static final String FOREGROUND_LAYER = "mapbox-location-foreground-layer";
 


### PR DESCRIPTION
This commit updates the docs to make sure that the FOREGROUND_LAYER constant is usable for relative positioning in both normal and specialized location layer rendering modes.

```
<changelog>Updated specialized location layer's compatibility docs to highlight that `LocationComponentConstants#FOREGROUND_LAYER` can still be used for relative layer positioning.</changelog>
```