### PR TITLE
Keep strong reference to background scheduler in geojson_source

### DIFF
--- a/MapboxGLAndroidSDK/src/cpp/style/sources/geojson_source.cpp
+++ b/MapboxGLAndroidSDK/src/cpp/style/sources/geojson_source.cpp
@@ -47,12 +47,14 @@ GeoJSONSource::GeoJSONSource(jni::JNIEnv& env, const jni::String& sourceId, cons
     : Source(env,
              std::make_unique<mbgl::style::GeoJSONSource>(jni::Make<std::string>(env, sourceId),
                                                           convertGeoJSONOptions(env, options))),
-      converter(std::make_unique<Actor<FeatureConverter>>(Scheduler::GetBackground(),
+      backgroundScheduler(Scheduler::GetBackground()),
+      converter(std::make_unique<Actor<FeatureConverter>>(*backgroundScheduler,
                                                           source.as<style::GeoJSONSource>()->impl().getOptions())) {}
 
 GeoJSONSource::GeoJSONSource(jni::JNIEnv& env, mbgl::style::Source& coreSource, AndroidRendererFrontend* frontend)
     : Source(env, coreSource, createJavaPeer(env), frontend),
-      converter(std::make_unique<Actor<FeatureConverter>>(Scheduler::GetBackground(),
+      backgroundScheduler(Scheduler::GetBackground()),
+      converter(std::make_unique<Actor<FeatureConverter>>(*backgroundScheduler,
                                                           source.as<style::GeoJSONSource>()->impl().getOptions())) {}
 
 GeoJSONSource::~GeoJSONSource() = default;

--- a/MapboxGLAndroidSDK/src/cpp/style/sources/geojson_source.hpp
+++ b/MapboxGLAndroidSDK/src/cpp/style/sources/geojson_source.hpp
@@ -65,7 +65,7 @@ private:
     jni::Local<jni::Object<Source>> createJavaPeer(jni::JNIEnv&);
     std::unique_ptr<Update> awaitingUpdate;
     std::unique_ptr<Update> update;
-    std::shared_ptr<ThreadPool> threadPool;
+    std::shared_ptr<Scheduler> backgroundScheduler;
     std::unique_ptr<Actor<FeatureConverter>> converter;
 
     template <class JNIType>


### PR DESCRIPTION
`<changelog>Introduced strong reference to background scheduler in geojson source.</changelog>`

Capturing from @alexshalamov :

> Actor holds reference to scheduler (Scheduler&). If non-owned source would be converting feature, background scheduler could be destructed if map instance is destructed. I would rather keep strong reference to background scheduler.
