### PR TITLE
Not change file source status while changing cache path.

### DIFF
--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/storage/FileSource.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/storage/FileSource.java
@@ -329,7 +329,6 @@ public class FileSource {
     fileSource.setResourceCachePath(path, new ResourcesCachePathChangeCallback() {
       @Override
       public void onSuccess(@NonNull String path) {
-        fileSource.deactivate();
         resourcesCachePathLoaderLock.lock();
         resourcesCachePath = path;
         resourcesCachePathLoaderLock.unlock();
@@ -342,7 +341,6 @@ public class FileSource {
         callback.onError(message);
       }
     });
-    fileSource.activate();
   }
 
   private static boolean isPathWritable(String path) {

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/storage/FileSource.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/storage/FileSource.java
@@ -293,12 +293,7 @@ public class FileSource {
     final Context applicationContext = Mapbox.getApplicationContext();
     final FileSource fileSource = FileSource.getInstance(applicationContext);
 
-    if (fileSource.isActivated()) {
-      String fileSourceActivatedMessage = "Cannot set path, file source is activated."
-        + " Make sure that the map or a resources download is not running.";
-      Logger.w(TAG, fileSourceActivatedMessage);
-      callback.onError(fileSourceActivatedMessage);
-    } else if (path.equals(getResourcesCachePath(applicationContext))) {
+    if (path.equals(getResourcesCachePath(applicationContext))) {
       // no need to change the path
       callback.onSuccess(path);
     } else {
@@ -326,9 +321,17 @@ public class FileSource {
   private static void internalSetResourcesCachePath(@NonNull Context context, @NonNull String path,
                                                     @NonNull final ResourcesCachePathChangeCallback callback) {
     final FileSource fileSource = getInstance(context);
+    final boolean active = fileSource.isActivated();
+    if (!active) {
+      fileSource.activate();
+    }
+
     fileSource.setResourceCachePath(path, new ResourcesCachePathChangeCallback() {
       @Override
       public void onSuccess(@NonNull String path) {
+        if (!active) {
+          fileSource.deactivate();
+        }
         resourcesCachePathLoaderLock.lock();
         resourcesCachePath = path;
         resourcesCachePathLoaderLock.unlock();
@@ -337,6 +340,9 @@ public class FileSource {
 
       @Override
       public void onError(@NonNull String message) {
+        if (!active) {
+          fileSource.deactivate();
+        }
         callback.onError(message);
       }
     });

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/storage/FileSource.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/storage/FileSource.java
@@ -337,7 +337,6 @@ public class FileSource {
 
       @Override
       public void onError(@NonNull String message) {
-        fileSource.deactivate();
         callback.onError(message);
       }
     });

--- a/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/storage/FileSourceMapTest.kt
+++ b/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/storage/FileSourceMapTest.kt
@@ -39,13 +39,12 @@ open class FileSourceMapTest : AppCenter() {
     rule.activity.runOnUiThread {
       FileSource.setResourcesCachePath(fileSourceTestUtils.testPath, object : FileSource.ResourcesCachePathChangeCallback {
         override fun onSuccess(path: String) {
-          Assert.fail("Requested resources change while the map is running should fail")
+          latch.countDown()
+          Assert.assertEquals(fileSourceTestUtils.testPath, path)
         }
 
         override fun onError(message: String) {
-          Assert.assertEquals("Cannot set path, file source is activated." +
-            " Make sure that the map or a resources download is not running.", message)
-          latch.countDown()
+          Assert.fail("Resources path can be changed while the map is running")
         }
       })
     }

--- a/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/storage/FileSourceStandaloneTest.kt
+++ b/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/storage/FileSourceStandaloneTest.kt
@@ -95,18 +95,10 @@ class FileSourceStandaloneTest : AppCenter() {
     }
 
     if (!secondLatch.await(5, TimeUnit.SECONDS)) {
-      rule.runOnUiThread {
-        // if we fail to call a callback, the file source is not going to be deactivated
-        fileSource.deactivate()
-      }
       Assert.fail("Second attempt should fail.")
     }
 
     if (!firstLatch.await(5, TimeUnit.SECONDS)) {
-      rule.runOnUiThread {
-        // if we fail to call a callback, the file source is not going to be deactivated
-        fileSource.deactivate()
-      }
       Assert.fail("First attempt should succeed.")
     }
   }

--- a/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/storage/FileSourceStandaloneTest.kt
+++ b/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/storage/FileSourceStandaloneTest.kt
@@ -55,9 +55,11 @@ class FileSourceStandaloneTest : AppCenter() {
 
     fileSourceTestUtils.changePath(fileSourceTestUtils.testPath)
     Assert.assertEquals(fileSourceTestUtils.testPath, FileSource.getResourcesCachePath(rule.activity))
+    Assert.assertFalse("FileSource should not be active", fileSource.isActivated)
 
     fileSourceTestUtils.changePath(fileSourceTestUtils.originalPath)
     Assert.assertEquals(fileSourceTestUtils.originalPath, FileSource.getResourcesCachePath(rule.activity))
+    Assert.assertFalse("FileSource should not be active", fileSource.isActivated)
   }
 
   @Test

--- a/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/storage/FileSourceStandaloneTest.kt
+++ b/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/storage/FileSourceStandaloneTest.kt
@@ -35,31 +35,31 @@ class FileSourceStandaloneTest : AppCenter() {
   @Test
   @UiThreadTest
   fun testDefault() {
-    Assert.assertFalse("FileSource should not be active", fileSource.isActivated)
+    Assert.assertTrue("FileSource should be active", fileSource.isActivated)
   }
 
   @Test
   @UiThreadTest
   fun testActivateDeactivate() {
-    Assert.assertFalse("1) FileSource should not be active", fileSource.isActivated)
-    fileSource.activate()
-    Assert.assertTrue("2) FileSource should be active", fileSource.isActivated)
+    Assert.assertTrue("1) FileSource should be active", fileSource.isActivated)
     fileSource.deactivate()
-    Assert.assertFalse("3) FileSource should not be active", fileSource.isActivated)
+    Assert.assertFalse("2) FileSource should not be active", fileSource.isActivated)
+    fileSource.activate()
+    Assert.assertTrue("3) FileSource should be active", fileSource.isActivated)
   }
 
   @Test
   fun pathChangeTest() {
-    Assert.assertFalse("FileSource should not be active", fileSource.isActivated)
+    Assert.assertTrue("FileSource should be active", fileSource.isActivated)
     Assert.assertEquals(fileSourceTestUtils.originalPath, FileSource.getResourcesCachePath(rule.activity))
 
     fileSourceTestUtils.changePath(fileSourceTestUtils.testPath)
     Assert.assertEquals(fileSourceTestUtils.testPath, FileSource.getResourcesCachePath(rule.activity))
-    Assert.assertFalse("FileSource should not be active", fileSource.isActivated)
+    Assert.assertTrue("FileSource should be active", fileSource.isActivated)
 
     fileSourceTestUtils.changePath(fileSourceTestUtils.originalPath)
     Assert.assertEquals(fileSourceTestUtils.originalPath, FileSource.getResourcesCachePath(rule.activity))
-    Assert.assertFalse("FileSource should not be active", fileSource.isActivated)
+    Assert.assertTrue("FileSource should be active", fileSource.isActivated)
   }
 
   @Test


### PR DESCRIPTION
` fileSource.deactivate()` will pause `MainResourceLoader` and so that it will not work for loading local resources.

This PR removes the process of changing fileSource status to keep `MainResourceLoader` running.


