### PR TITLE
Smooth puck animation after changing style.

### DIFF
--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinator.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinator.java
@@ -502,7 +502,6 @@ final class LocationAnimatorCoordinator {
       animator.cancel();
       animator.removeAllUpdateListeners();
       animator.removeAllListeners();
-      animatorArray.put(animatorType, null);
     }
   }
 

--- a/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinatorTest.kt
+++ b/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinatorTest.kt
@@ -14,8 +14,7 @@ import com.mapbox.mapboxsdk.location.modes.RenderMode
 import com.mapbox.mapboxsdk.maps.MapboxMap
 import com.mapbox.mapboxsdk.maps.Projection
 import io.mockk.*
-import junit.framework.Assert.assertEquals
-import junit.framework.Assert.assertTrue
+import junit.framework.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -462,7 +461,7 @@ class LocationAnimatorCoordinatorTest {
     locationAnimatorCoordinator.feedNewLocation(Location(""), cameraPosition, true)
     locationAnimatorCoordinator.cancelAllAnimations()
 
-    assertTrue(locationAnimatorCoordinator.animatorArray[ANIMATOR_CAMERA_LATLNG] == null)
+    assertFalse(locationAnimatorCoordinator.animatorArray[ANIMATOR_CAMERA_LATLNG].isRunning)
   }
 
   @Test
@@ -475,7 +474,7 @@ class LocationAnimatorCoordinatorTest {
     )
     locationAnimatorCoordinator.cancelZoomAnimation()
 
-    assertTrue(locationAnimatorCoordinator.animatorArray[ANIMATOR_ZOOM] == null)
+    assertFalse(locationAnimatorCoordinator.animatorArray[ANIMATOR_ZOOM].isRunning)
   }
 
   @Test
@@ -489,7 +488,7 @@ class LocationAnimatorCoordinatorTest {
 
     locationAnimatorCoordinator.cancelTiltAnimation()
 
-    assertTrue(locationAnimatorCoordinator.animatorArray[ANIMATOR_TILT] == null)
+    assertFalse(locationAnimatorCoordinator.animatorArray[ANIMATOR_TILT].isRunning)
   }
 
   @Test

--- a/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinatorTest.kt
+++ b/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinatorTest.kt
@@ -53,7 +53,7 @@ class LocationAnimatorCoordinatorTest {
     ))
   }
 
-  private fun configureAnimatorProvider() {
+  private fun configureAnimatorProvider(withMocks: Boolean = false) {
     // workaround https://github.com/mockk/mockk/issues/229#issuecomment-457816131
     registerInstanceFactory { AnimationsValueChangeListener<Float> {} }
     registerInstanceFactory { AnimationsValueChangeListener<LatLng> {} }
@@ -63,26 +63,26 @@ class LocationAnimatorCoordinatorTest {
     every {
       animatorProvider.floatAnimator(capture(floatsSlot), capture(listenerSlot), capture(maxFpsSlot))
     } answers {
-      MapboxFloatAnimator(floatsSlot.captured, listenerSlot.captured, maxFpsSlot.captured)
+      if (withMocks) mockk(relaxUnitFun = true) else MapboxFloatAnimator(floatsSlot.captured, listenerSlot.captured, maxFpsSlot.captured)
     }
 
     val latLngsSlot = slot<Array<LatLng>>()
     every {
       animatorProvider.latLngAnimator(capture(latLngsSlot), capture(listenerSlot), capture(maxFpsSlot))
     } answers {
-      MapboxLatLngAnimator(latLngsSlot.captured, listenerSlot.captured, maxFpsSlot.captured)
+      if (withMocks) mockk(relaxUnitFun = true) else MapboxLatLngAnimator(latLngsSlot.captured, listenerSlot.captured, maxFpsSlot.captured)
     }
 
     val callback = slot<MapboxMap.CancelableCallback>()
     every {
       animatorProvider.cameraAnimator(capture(floatsSlot), capture(listenerSlot), capture(callback))
     } answers {
-      MapboxCameraAnimatorAdapter(floatsSlot.captured, listenerSlot.captured, callback.captured)
+      if (withMocks) mockk(relaxUnitFun = true) else MapboxCameraAnimatorAdapter(floatsSlot.captured, listenerSlot.captured, callback.captured)
     }
     every {
       animatorProvider.cameraAnimator(capture(floatsSlot), capture(listenerSlot), null)
     } answers {
-      MapboxCameraAnimatorAdapter(floatsSlot.captured, listenerSlot.captured, null)
+      if (withMocks) mockk(relaxUnitFun = true) else MapboxCameraAnimatorAdapter(floatsSlot.captured, listenerSlot.captured, null)
     }
   }
 
@@ -458,14 +458,16 @@ class LocationAnimatorCoordinatorTest {
 
   @Test
   fun cancelAllAnimators() {
+    configureAnimatorProvider(withMocks = true)
     locationAnimatorCoordinator.feedNewLocation(Location(""), cameraPosition, true)
     locationAnimatorCoordinator.cancelAllAnimations()
 
-    assertFalse(locationAnimatorCoordinator.animatorArray[ANIMATOR_CAMERA_LATLNG].isRunning)
+    verify { locationAnimatorCoordinator.animatorArray[ANIMATOR_CAMERA_LATLNG].cancel() }
   }
 
   @Test
   fun cancelZoomAnimators() {
+    configureAnimatorProvider(withMocks = true)
     locationAnimatorCoordinator.feedNewZoomLevel(
       15.0,
       cameraPosition,
@@ -474,11 +476,12 @@ class LocationAnimatorCoordinatorTest {
     )
     locationAnimatorCoordinator.cancelZoomAnimation()
 
-    assertFalse(locationAnimatorCoordinator.animatorArray[ANIMATOR_ZOOM].isRunning)
+    verify { locationAnimatorCoordinator.animatorArray[ANIMATOR_ZOOM].cancel() }
   }
 
   @Test
   fun cancelTiltAnimation() {
+    configureAnimatorProvider(withMocks = true)
     locationAnimatorCoordinator.feedNewTilt(
       30.0,
       cameraPosition,
@@ -488,7 +491,7 @@ class LocationAnimatorCoordinatorTest {
 
     locationAnimatorCoordinator.cancelTiltAnimation()
 
-    assertFalse(locationAnimatorCoordinator.animatorArray[ANIMATOR_TILT].isRunning)
+    verify { locationAnimatorCoordinator.animatorArray[ANIMATOR_TILT].cancel() }
   }
 
   @Test

--- a/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinatorTest.kt
+++ b/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinatorTest.kt
@@ -464,6 +464,8 @@ class LocationAnimatorCoordinatorTest {
   @Test
   fun cancelAllAnimators() {
     locationAnimatorCoordinator.feedNewLocation(Location(""), cameraPosition, true)
+    assertTrue(locationAnimatorCoordinator.animatorArray[ANIMATOR_CAMERA_LATLNG].isStarted)
+
     locationAnimatorCoordinator.cancelAllAnimations()
 
     assertFalse(locationAnimatorCoordinator.animatorArray[ANIMATOR_CAMERA_LATLNG].isStarted)
@@ -477,6 +479,8 @@ class LocationAnimatorCoordinatorTest {
       DEFAULT_TRACKING_ZOOM_ANIM_DURATION,
       null
     )
+    assertTrue(locationAnimatorCoordinator.animatorArray[ANIMATOR_ZOOM].isStarted)
+
     locationAnimatorCoordinator.cancelZoomAnimation()
 
     assertFalse(locationAnimatorCoordinator.animatorArray[ANIMATOR_ZOOM].isStarted)
@@ -490,6 +494,7 @@ class LocationAnimatorCoordinatorTest {
       DEFAULT_TRACKING_TILT_ANIM_DURATION,
       null
     )
+    assertTrue(locationAnimatorCoordinator.animatorArray[ANIMATOR_TILT].isStarted)
 
     locationAnimatorCoordinator.cancelTiltAnimation()
 


### PR DESCRIPTION
Resolves #431 

If puck animation is interrupted by changing style, the puck animation will be stopped at its current position and resumed from its target position. So it looks like puck jumps to the new position. This pr smooth puck animation by recording its breakpoint and resume from this point. 


![ezgif com-resize](https://user-images.githubusercontent.com/8577318/85253510-ea744480-b490-11ea-9282-2846e58009e0.gif)
