### PR TITLE
[build] allow building from source when externally used

### DIFF
--- a/MapboxGLAndroidSDK/build.gradle
+++ b/MapboxGLAndroidSDK/build.gradle
@@ -9,7 +9,12 @@ dependencies {
     api dependenciesList.mapboxJavaGeoJSON
     api dependenciesList.mapboxAndroidGestures
     api dependenciesList.mapboxAndroidAccounts
-    api dependenciesList.mapboxSdkCore
+
+    if (!project.findProperty('buildFromSource')) {
+        api dependenciesList.mapboxSdkCore
+    } else {
+        api project(":MapboxGLAndroidSDKCore")
+    }
     implementation dependenciesList.mapboxJavaTurf
     implementation dependenciesList.supportAnnotations
     implementation dependenciesList.supportFragmentV4


### PR DESCRIPTION
This PR introduces a check that verifies if a gralde.properties flag is set to determine if we should build from source vs using a binary release. 

