### PR TITLE
Cherry-pick  (#429) Not change file source status while changing cache path.

### DIFF
--- a/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/storage/FileSourceMapTest.kt
+++ b/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/storage/FileSourceMapTest.kt
@@ -39,13 +39,12 @@ open class FileSourceMapTest : AppCenter() {
     rule.activity.runOnUiThread {
       FileSource.setResourcesCachePath(fileSourceTestUtils.testPath, object : FileSource.ResourcesCachePathChangeCallback {
         override fun onSuccess(path: String) {
-          Assert.fail("Requested resources change while the map is running should fail")
+          latch.countDown()
+          Assert.assertEquals(fileSourceTestUtils.testPath, path)
         }
 
         override fun onError(message: String) {
-          Assert.assertEquals("Cannot set path, file source is activated." +
-            " Make sure that the map or a resources download is not running.", message)
-          latch.countDown()
+          Assert.fail("Resources path can be changed while the map is running")
         }
       })
     }

--- a/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/storage/FileSourceStandaloneTest.kt
+++ b/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/storage/FileSourceStandaloneTest.kt
@@ -35,29 +35,31 @@ class FileSourceStandaloneTest : AppCenter() {
   @Test
   @UiThreadTest
   fun testDefault() {
-    Assert.assertFalse("FileSource should not be active", fileSource.isActivated)
+    Assert.assertTrue("FileSource should be active", fileSource.isActivated)
   }
 
   @Test
   @UiThreadTest
   fun testActivateDeactivate() {
-    Assert.assertFalse("1) FileSource should not be active", fileSource.isActivated)
-    fileSource.activate()
-    Assert.assertTrue("2) FileSource should be active", fileSource.isActivated)
+    Assert.assertTrue("1) FileSource should be active", fileSource.isActivated)
     fileSource.deactivate()
-    Assert.assertFalse("3) FileSource should not be active", fileSource.isActivated)
+    Assert.assertFalse("2) FileSource should not be active", fileSource.isActivated)
+    fileSource.activate()
+    Assert.assertTrue("3) FileSource should be active", fileSource.isActivated)
   }
 
   @Test
   fun pathChangeTest() {
-    Assert.assertFalse("FileSource should not be active", fileSource.isActivated)
+    Assert.assertTrue("FileSource should be active", fileSource.isActivated)
     Assert.assertEquals(fileSourceTestUtils.originalPath, FileSource.getResourcesCachePath(rule.activity))
 
     fileSourceTestUtils.changePath(fileSourceTestUtils.testPath)
     Assert.assertEquals(fileSourceTestUtils.testPath, FileSource.getResourcesCachePath(rule.activity))
+    Assert.assertTrue("FileSource should be active", fileSource.isActivated)
 
     fileSourceTestUtils.changePath(fileSourceTestUtils.originalPath)
     Assert.assertEquals(fileSourceTestUtils.originalPath, FileSource.getResourcesCachePath(rule.activity))
+    Assert.assertTrue("FileSource should be active", fileSource.isActivated)
   }
 
   @Test
@@ -93,18 +95,10 @@ class FileSourceStandaloneTest : AppCenter() {
     }
 
     if (!secondLatch.await(5, TimeUnit.SECONDS)) {
-      rule.runOnUiThread {
-        // if we fail to call a callback, the file source is not going to be deactivated
-        fileSource.deactivate()
-      }
       Assert.fail("Second attempt should fail.")
     }
 
     if (!firstLatch.await(5, TimeUnit.SECONDS)) {
-      rule.runOnUiThread {
-        // if we fail to call a callback, the file source is not going to be deactivated
-        fileSource.deactivate()
-      }
       Assert.fail("First attempt should succeed.")
     }
   }


### PR DESCRIPTION
This pr cherry-pick #429 java changes.
Resolves #451 
