### PR TITLE
Set gps bearing immediately while changing to gps mode.

### DIFF
--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinator.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinator.java
@@ -482,6 +482,11 @@ final class LocationAnimatorCoordinator {
     cancelAnimator(ANIMATOR_TILT);
   }
 
+  void cancelAndRemoveGpsBearingAnimation() {
+    cancelAnimator(ANIMATOR_LAYER_GPS_BEARING);
+    animatorArray.remove(ANIMATOR_LAYER_GPS_BEARING);
+  }
+
   /**
    * Cancel the pulsing circle location animator.
    */

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
@@ -48,6 +48,7 @@ import static com.mapbox.mapboxsdk.location.LocationComponentConstants.DEFAULT_I
 import static com.mapbox.mapboxsdk.location.LocationComponentConstants.DEFAULT_TRACKING_TILT_ANIM_DURATION;
 import static com.mapbox.mapboxsdk.location.LocationComponentConstants.DEFAULT_TRACKING_ZOOM_ANIM_DURATION;
 import static com.mapbox.mapboxsdk.location.LocationComponentConstants.TRANSITION_ANIMATION_DURATION_MS;
+import static com.mapbox.mapboxsdk.location.modes.RenderMode.GPS;
 
 /**
  * The Location Component provides location awareness to your mobile application. Enabling this
@@ -673,6 +674,10 @@ public final class LocationComponent {
    */
   public void setRenderMode(@RenderMode.Mode int renderMode) {
     checkActivationState();
+    if (lastLocation != null && renderMode == GPS) {
+      locationAnimatorCoordinator.cancelAndRemoveGpsBearingAnimation();
+      locationLayerController.setGpsBearing(lastLocation.getBearing());
+    }
     locationLayerController.setRenderMode(renderMode);
     updateLayerOffsets(true);
     updateCompassListenerState(true);

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationLayerController.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationLayerController.java
@@ -106,6 +106,10 @@ final class LocationLayerController {
     }
   }
 
+  void setGpsBearing(float gpsBearing) {
+    locationLayerRenderer.setGpsBearing(gpsBearing);
+  }
+
   void setRenderMode(@RenderMode.Mode int renderMode) {
     if (this.renderMode == renderMode) {
       return;

--- a/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinatorTest.kt
+++ b/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinatorTest.kt
@@ -677,6 +677,15 @@ class LocationAnimatorCoordinatorTest {
     verify { animatorProvider.floatAnimator(any(), any(), 5) }
   }
 
+  @Test
+  fun remove_gps_animator() {
+    val animator = mockk<MapboxFloatAnimator>(relaxed = true)
+    locationAnimatorCoordinator.animatorArray.put(ANIMATOR_LAYER_GPS_BEARING, animator)
+
+    locationAnimatorCoordinator.cancelAndRemoveGpsBearingAnimation()
+    assertTrue(locationAnimatorCoordinator.animatorArray.get(ANIMATOR_LAYER_GPS_BEARING) == null)
+  }
+
   private fun getListenerHoldersSet(vararg animatorTypes: Int): Set<AnimatorListenerHolder> {
     return HashSet<AnimatorListenerHolder>().also {
       for (type in animatorTypes) {

--- a/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
+++ b/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
@@ -470,6 +470,34 @@ class LocationComponentTest {
   }
 
   @Test
+  fun change_to_gps_mode_symbolLayerBearingValue() {
+    val location = Location("test")
+    location.bearing = 50f
+    val projection: Projection = mock(Projection::class.java)
+    `when`(projection.getMetersPerPixelAtLatitude(location.latitude)).thenReturn(10.0)
+    `when`(mapboxMap.projection).thenReturn(projection)
+    `when`(style.isFullyLoaded).thenReturn(true)
+    `when`(mapboxMap.cameraPosition).thenReturn(CameraPosition.DEFAULT)
+
+    locationComponent.activateLocationComponent(
+      LocationComponentActivationOptions.builder(context, style)
+        .locationComponentOptions(locationComponentOptions)
+        .useDefaultLocationEngine(false)
+        .build()
+    )
+    locationComponent.isLocationComponentEnabled = true
+    locationComponent.onStart()
+    locationComponent.renderMode = RenderMode.NORMAL
+    locationComponent.forceLocationUpdate(location)
+
+    verify(locationLayerController, times(0)).setGpsBearing(50f)
+
+    locationComponent.renderMode = RenderMode.GPS
+    verify(locationLayerController, times(1)).setGpsBearing(50f)
+    verify(locationAnimatorCoordinator).cancelAndRemoveGpsBearingAnimation()
+  }
+
+  @Test
   fun tiltWhileTracking_notReady() {
     `when`(mapboxMap.cameraPosition).thenReturn(CameraPosition.DEFAULT)
     locationComponent.activateLocationComponent(context, mock(Style::class.java), locationEngine, locationEngineRequest, locationComponentOptions)


### PR DESCRIPTION
Cache gps bearing while in normal and compass mode and then set it to render when changing to GPS mode.
Resolves #462 
