### PR TITLE
Update to gl-native release v1.8.3

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -40,7 +40,7 @@ ext {
             ktlint           : '0.34.0',
             commonsIO        : '2.6',
             mapboxSdkVersions: '1.0.1',
-            mapboxSdkCore    : '1.8.1'
+            mapboxSdkCore    : '1.8.3'
     ]
 
     dependenciesList = [


### PR DESCRIPTION
Updates to the latest patch release of v1.8.3 (release variant vs debug).

