### PR TITLE
Implement method to set padding when camera is tracking.

### DIFF
--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinator.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinator.java
@@ -33,6 +33,7 @@ import static com.mapbox.mapboxsdk.location.MapboxAnimator.ANIMATOR_LAYER_ACCURA
 import static com.mapbox.mapboxsdk.location.MapboxAnimator.ANIMATOR_LAYER_COMPASS_BEARING;
 import static com.mapbox.mapboxsdk.location.MapboxAnimator.ANIMATOR_LAYER_GPS_BEARING;
 import static com.mapbox.mapboxsdk.location.MapboxAnimator.ANIMATOR_LAYER_LATLNG;
+import static com.mapbox.mapboxsdk.location.MapboxAnimator.ANIMATOR_PADDING;
 import static com.mapbox.mapboxsdk.location.MapboxAnimator.ANIMATOR_PULSING_CIRCLE;
 import static com.mapbox.mapboxsdk.location.MapboxAnimator.ANIMATOR_TILT;
 import static com.mapbox.mapboxsdk.location.MapboxAnimator.ANIMATOR_ZOOM;
@@ -216,6 +217,12 @@ final class LocationAnimatorCoordinator {
     playAnimators(animationDuration, ANIMATOR_ZOOM);
   }
 
+  void feedNewPadding(double[] padding, @NonNull CameraPosition currentCameraPosition, long animationDuration,
+      @Nullable MapboxMap.CancelableCallback callback) {
+    updatePaddingAnimator(padding, currentCameraPosition.padding, callback);
+    playAnimators(animationDuration, ANIMATOR_PADDING);
+  }
+
   void feedNewTilt(double targetTilt, @NonNull CameraPosition currentCameraPosition, long animationDuration,
                    @Nullable MapboxMap.CancelableCallback callback) {
     updateTiltAnimator((float) targetTilt, (float) currentCameraPosition.tilt, callback);
@@ -316,6 +323,11 @@ final class LocationAnimatorCoordinator {
     createNewCameraAdapterAnimator(ANIMATOR_ZOOM, new Float[] {previousZoomLevel, targetZoomLevel}, cancelableCallback);
   }
 
+  private void updatePaddingAnimator(double[] targetPadding, double[] previousPadding,
+      @Nullable MapboxMap.CancelableCallback cancelableCallback) {
+    createNewPaddingAnimator(ANIMATOR_PADDING, new double[][] {previousPadding, targetPadding}, cancelableCallback);
+  }
+
   private void updateTiltAnimator(float targetTilt, float previousTiltLevel,
                                   @Nullable MapboxMap.CancelableCallback cancelableCallback) {
     createNewCameraAdapterAnimator(ANIMATOR_TILT, new Float[] {previousTiltLevel, targetTilt}, cancelableCallback);
@@ -352,6 +364,16 @@ final class LocationAnimatorCoordinator {
     MapboxAnimator.AnimationsValueChangeListener listener = listeners.get(animatorType);
     if (listener != null) {
       animatorArray.put(animatorType, animatorProvider.cameraAnimator(values, listener, cancelableCallback));
+    }
+  }
+
+  private void createNewPaddingAnimator(@MapboxAnimator.Type int animatorType,
+      @NonNull @Size(min = 2) double[][] values,
+      @Nullable MapboxMap.CancelableCallback cancelableCallback) {
+    cancelAnimator(animatorType);
+    MapboxAnimator.AnimationsValueChangeListener listener = listeners.get(animatorType);
+    if (listener != null) {
+      animatorArray.put(animatorType, animatorProvider.paddingAnimator(values, listener, cancelableCallback));
     }
   }
 
@@ -476,6 +498,10 @@ final class LocationAnimatorCoordinator {
 
   void cancelZoomAnimation() {
     cancelAnimator(ANIMATOR_ZOOM);
+  }
+
+  void cancelPaddingAnimation() {
+    cancelAnimator(ANIMATOR_PADDING);
   }
 
   void cancelTiltAnimation() {

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationCameraController.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationCameraController.java
@@ -223,6 +223,15 @@ final class LocationCameraController {
     onCameraMoveInvalidateListener.onInvalidateCameraMove();
   }
 
+  private void setPadding(double[] padding) {
+    if (isTransitioning) {
+      return;
+    }
+
+    transform.moveCamera(mapboxMap, CameraUpdateFactory.paddingTo(padding), null);
+    onCameraMoveInvalidateListener.onInvalidateCameraMove();
+  }
+
   private void setTilt(float tilt) {
     if (isTransitioning) {
       return;
@@ -272,6 +281,14 @@ final class LocationCameraController {
       }
     };
 
+  private final MapboxAnimator.AnimationsValueChangeListener<double[]> paddingValueListener =
+    new MapboxAnimator.AnimationsValueChangeListener<double[]>() {
+      @Override
+      public void onNewAnimationValue(double[] value) {
+        setPadding(value);
+      }
+    };
+
   private final MapboxAnimator.AnimationsValueChangeListener<Float> tiltValueListener =
     new MapboxAnimator.AnimationsValueChangeListener<Float>() {
       @Override
@@ -298,6 +315,7 @@ final class LocationCameraController {
 
     holders.add(new AnimatorListenerHolder(MapboxAnimator.ANIMATOR_ZOOM, zoomValueListener));
     holders.add(new AnimatorListenerHolder(MapboxAnimator.ANIMATOR_TILT, tiltValueListener));
+    holders.add(new AnimatorListenerHolder(MapboxAnimator.ANIMATOR_PADDING, paddingValueListener));
     return holders;
   }
 

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponent.java
@@ -45,6 +45,7 @@ import static android.Manifest.permission.ACCESS_COARSE_LOCATION;
 import static android.Manifest.permission.ACCESS_FINE_LOCATION;
 import static com.mapbox.mapboxsdk.location.LocationComponentConstants.DEFAULT_FASTEST_INTERVAL_MILLIS;
 import static com.mapbox.mapboxsdk.location.LocationComponentConstants.DEFAULT_INTERVAL_MILLIS;
+import static com.mapbox.mapboxsdk.location.LocationComponentConstants.DEFAULT_TRACKING_PADDING_ANIM_DURATION;
 import static com.mapbox.mapboxsdk.location.LocationComponentConstants.DEFAULT_TRACKING_TILT_ANIM_DURATION;
 import static com.mapbox.mapboxsdk.location.LocationComponentConstants.DEFAULT_TRACKING_ZOOM_ANIM_DURATION;
 import static com.mapbox.mapboxsdk.location.LocationComponentConstants.TRANSITION_ANIMATION_DURATION_MS;
@@ -828,6 +829,84 @@ public final class LocationComponent {
   public void cancelZoomWhileTrackingAnimation() {
     checkActivationState();
     locationAnimatorCoordinator.cancelZoomAnimation();
+  }
+
+  /**
+   * Sets the padding.
+   * This API can only be used in pair with camera modes other than {@link CameraMode#NONE}.
+   * If you are not using any of {@link CameraMode} modes,
+   * use one of {@link MapboxMap#moveCamera(CameraUpdate)},
+   * {@link MapboxMap#easeCamera(CameraUpdate)} or {@link MapboxMap#animateCamera(CameraUpdate)} instead.
+   * <p>
+   * If the camera is transitioning when the padding change is requested, the call is going to be ignored.
+   * Use {@link CameraTransitionListener} to chain the animations, or provide the padding as a camera change argument.
+   * </p>
+   *
+   * @param padding The desired padding.
+   */
+  public void paddingWhileTracking(double[] padding) {
+    paddingWhileTracking(padding, DEFAULT_TRACKING_PADDING_ANIM_DURATION, null);
+  }
+
+  /**
+   * Sets the padding.
+   * This API can only be used in pair with camera modes other than {@link CameraMode#NONE}.
+   * If you are not using any of {@link CameraMode} modes,
+   * use one of {@link MapboxMap#moveCamera(CameraUpdate)},
+   * {@link MapboxMap#easeCamera(CameraUpdate)} or {@link MapboxMap#animateCamera(CameraUpdate)} instead.
+   * <p>
+   * If the camera is transitioning when the padding change is requested, the call is going to be ignored.
+   * Use {@link CameraTransitionListener} to chain the animations, or provide the padding as a camera change argument.
+   * </p>
+   *
+   * @param padding           The desired padding.
+   * @param animationDuration The padding animation duration.
+   */
+  public void paddingWhileTracking(double[] padding, long animationDuration) {
+    paddingWhileTracking(padding, animationDuration, null);
+  }
+
+  /**
+   * Sets the padding.
+   * This API can only be used in pair with camera modes other than {@link CameraMode#NONE}.
+   * If you are not using any of {@link CameraMode} modes,
+   * use one of {@link MapboxMap#moveCamera(CameraUpdate)},
+   * {@link MapboxMap#easeCamera(CameraUpdate)} or {@link MapboxMap#animateCamera(CameraUpdate)} instead.
+   * <p>
+   * If the camera is transitioning when the padding change is requested, the call is going to be ignored.
+   * Use {@link CameraTransitionListener} to chain the animations, or provide the padding as a camera change argument.
+   * </p>
+   *
+   * @param padding           The desired padding.
+   * @param animationDuration The padding animation duration.
+   * @param callback          The callback with finish/cancel information
+   */
+  public void paddingWhileTracking(double[] padding, long animationDuration,
+      @Nullable MapboxMap.CancelableCallback callback) {
+    checkActivationState();
+    if (!isLayerReady) {
+      notifyUnsuccessfulCameraOperation(callback, null);
+      return;
+    } else if (getCameraMode() == CameraMode.NONE) {
+      notifyUnsuccessfulCameraOperation(callback, String.format("%s%s",
+          "LocationComponent#paddingWhileTracking method can only be used",
+          " when a camera mode other than CameraMode#NONE is engaged."));
+      return;
+    } else if (locationCameraController.isTransitioning()) {
+      notifyUnsuccessfulCameraOperation(callback,
+          "LocationComponent#paddingWhileTracking method call is ignored because the camera mode is transitioning");
+      return;
+    }
+
+    locationAnimatorCoordinator.feedNewPadding(padding, mapboxMap.getCameraPosition(), animationDuration, callback);
+  }
+
+  /**
+   * Cancels animation started by {@link #paddingWhileTracking(double[], long, MapboxMap.CancelableCallback)}.
+   */
+  public void cancelPaddingWhileTrackingAnimation() {
+    checkActivationState();
+    locationAnimatorCoordinator.cancelPaddingAnimation();
   }
 
   /**

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentConstants.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentConstants.java
@@ -20,6 +20,9 @@ public final class LocationComponentConstants {
   // Default animation duration for zooming while tracking.
   static final long DEFAULT_TRACKING_ZOOM_ANIM_DURATION = 750;
 
+  // Default animation duration for updating padding while tracking.
+  static final long DEFAULT_TRACKING_PADDING_ANIM_DURATION = 750;
+
   // Default animation duration for tilting while tracking.
   static final long DEFAULT_TRACKING_TILT_ANIM_DURATION = 1250;
 

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentOptions.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationComponentOptions.java
@@ -1729,8 +1729,11 @@ public class LocationComponentOptions implements Parcelable {
      * </p>
      *
      * @param padding The margins for the map in pixels (left, top, right, bottom).
-     * @deprecated Use {@link CameraPosition.Builder#padding(double, double, double, double)}
-     * or {@link CameraUpdateFactory#paddingTo(double, double, double, double)} instead.
+     * @deprecated Use {@link com.mapbox.mapboxsdk.camera.CameraPosition.Builder#padding(double[])}
+     * or {@link com.mapbox.mapboxsdk.camera.CameraUpdateFactory#paddingTo(double[])}
+     * when not tracking and
+     * {@link LocationComponent#paddingWhileTracking(double[])}
+     * when {@link com.mapbox.mapboxsdk.location.modes.CameraMode} tracking is engaged to manipulate the padding.
      */
     @NonNull
     @Deprecated

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/MapboxAnimator.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/MapboxAnimator.java
@@ -29,7 +29,8 @@ abstract class MapboxAnimator<K> extends ValueAnimator implements ValueAnimator.
     ANIMATOR_LAYER_ACCURACY,
     ANIMATOR_ZOOM,
     ANIMATOR_TILT,
-    ANIMATOR_PULSING_CIRCLE
+    ANIMATOR_PULSING_CIRCLE,
+    ANIMATOR_PADDING
   })
   @interface Type {
   }
@@ -44,6 +45,7 @@ abstract class MapboxAnimator<K> extends ValueAnimator implements ValueAnimator.
   static final int ANIMATOR_ZOOM = 7;
   static final int ANIMATOR_TILT = 8;
   static final int ANIMATOR_PULSING_CIRCLE = 9;
+  static final int ANIMATOR_PADDING = 10;
 
   private final AnimationsValueChangeListener<K> updateListener;
   private final K target;

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/MapboxAnimatorListener.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/MapboxAnimatorListener.java
@@ -1,0 +1,30 @@
+package com.mapbox.mapboxsdk.location;
+
+import android.animation.Animator;
+import android.animation.AnimatorListenerAdapter;
+import androidx.annotation.Nullable;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+
+class MapboxAnimatorListener extends AnimatorListenerAdapter {
+
+  @Nullable
+  private final MapboxMap.CancelableCallback cancelableCallback;
+
+  MapboxAnimatorListener(@Nullable MapboxMap.CancelableCallback cancelableCallback) {
+    this.cancelableCallback = cancelableCallback;
+  }
+
+  @Override
+  public void onAnimationCancel(Animator animation) {
+    if (cancelableCallback != null) {
+      cancelableCallback.onCancel();
+    }
+  }
+
+  @Override
+  public void onAnimationEnd(Animator animation) {
+    if (cancelableCallback != null) {
+      cancelableCallback.onFinish();
+    }
+  }
+}

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/MapboxAnimatorProvider.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/MapboxAnimatorProvider.java
@@ -39,6 +39,13 @@ final class MapboxAnimatorProvider {
     return new MapboxCameraAnimatorAdapter(values, updateListener, cancelableCallback);
   }
 
+  MapboxPaddingAnimator paddingAnimator(double[][] values,
+      MapboxAnimator.AnimationsValueChangeListener<double[]> updateListener,
+      @Nullable MapboxMap.CancelableCallback cancelableCallback) {
+    return new MapboxPaddingAnimator(values, updateListener, cancelableCallback);
+  }
+
+
   /**
    * This animator is for the LocationComponent pulsing circle.
    *

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/MapboxPaddingAnimator.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/MapboxPaddingAnimator.java
@@ -1,16 +1,23 @@
 package com.mapbox.mapboxsdk.location;
 
+import android.animation.TypeEvaluator;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.Size;
-
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 
-class MapboxCameraAnimatorAdapter extends MapboxFloatAnimator {
-  MapboxCameraAnimatorAdapter(@NonNull @Size(min = 2) Float[] values,
-      AnimationsValueChangeListener updateListener,
+public class MapboxPaddingAnimator extends MapboxAnimator<double[]> {
+
+  MapboxPaddingAnimator(@NonNull @Size(min = 2) double[][] values,
+      @NonNull AnimationsValueChangeListener<double[]> updateListener,
       @Nullable MapboxMap.CancelableCallback cancelableCallback) {
     super(values, updateListener, Integer.MAX_VALUE);
     addListener(new MapboxAnimatorListener(cancelableCallback));
+  }
+
+  @NonNull
+  @Override
+  TypeEvaluator<double[]> provideEvaluator() {
+    return new PaddingEvaluator();
   }
 }

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/PaddingEvaluator.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/PaddingEvaluator.java
@@ -1,0 +1,20 @@
+package com.mapbox.mapboxsdk.location;
+
+import android.animation.TypeEvaluator;
+import androidx.annotation.NonNull;
+import androidx.annotation.Size;
+
+class PaddingEvaluator implements TypeEvaluator<double[]> {
+  private final double[] padding = new double[4];
+
+  @NonNull
+  @Override
+  public double[] evaluate(float fraction, @NonNull @Size(min = 4) double[] startValue,
+      @NonNull @Size(min = 4) double[] endValue) {
+    padding[0] = startValue[0] + (endValue[0] - startValue[0]) * fraction;
+    padding[1] = startValue[1] + (endValue[1] - startValue[1]) * fraction;
+    padding[2] = startValue[2] + (endValue[2] - startValue[2]) * fraction;
+    padding[3] = startValue[3] + (endValue[3] - startValue[3]) * fraction;
+    return padding;
+  }
+}

--- a/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinatorTest.kt
+++ b/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationAnimatorCoordinatorTest.kt
@@ -7,6 +7,7 @@ import android.util.SparseArray
 import android.view.animation.LinearInterpolator
 import com.mapbox.mapboxsdk.camera.CameraPosition
 import com.mapbox.mapboxsdk.geometry.LatLng
+import com.mapbox.mapboxsdk.location.LocationComponentConstants.DEFAULT_TRACKING_PADDING_ANIM_DURATION
 import com.mapbox.mapboxsdk.location.LocationComponentConstants.DEFAULT_TRACKING_TILT_ANIM_DURATION
 import com.mapbox.mapboxsdk.location.LocationComponentConstants.DEFAULT_TRACKING_ZOOM_ANIM_DURATION
 import com.mapbox.mapboxsdk.location.MapboxAnimator.*
@@ -54,7 +55,8 @@ class LocationAnimatorCoordinatorTest {
       ANIMATOR_CAMERA_COMPASS_BEARING,
       ANIMATOR_LAYER_ACCURACY,
       ANIMATOR_ZOOM,
-      ANIMATOR_TILT
+      ANIMATOR_TILT,
+      ANIMATOR_PADDING
     ))
   }
 
@@ -88,6 +90,19 @@ class LocationAnimatorCoordinatorTest {
       animatorProvider.cameraAnimator(capture(floatsSlot), capture(listenerSlot), null)
     } answers {
       MapboxCameraAnimatorAdapter(floatsSlot.captured, listenerSlot.captured, null)
+    }
+
+    val doubleArraySlot = slot<Array<DoubleArray>>()
+    val doubleArrayListenerSlot = slot<AnimationsValueChangeListener<DoubleArray>>()
+    every {
+      animatorProvider.paddingAnimator(capture(doubleArraySlot), capture(doubleArrayListenerSlot), capture(callback))
+    } answers {
+      MapboxPaddingAnimator(doubleArraySlot.captured, doubleArrayListenerSlot.captured, callback.captured)
+    }
+    every {
+      animatorProvider.paddingAnimator(capture(doubleArraySlot), capture(doubleArrayListenerSlot), null)
+    } answers {
+      MapboxPaddingAnimator(doubleArraySlot.captured, doubleArrayListenerSlot.captured, null)
     }
   }
 
@@ -464,6 +479,33 @@ class LocationAnimatorCoordinatorTest {
   }
 
   @Test
+  fun feedNewPadding_animatorsCreated() {
+    locationAnimatorCoordinator.feedNewPadding(
+      doubleArrayOf(100.0, 200.0, 300.0, 400.0),
+      cameraPosition,
+      DEFAULT_TRACKING_PADDING_ANIM_DURATION,
+      null
+    )
+
+    assertTrue(locationAnimatorCoordinator.animatorArray[ANIMATOR_PADDING] != null)
+  }
+
+  @Test
+  fun feedNewPadding_animatorValue() {
+    val padding = doubleArrayOf(100.0, 200.0, 300.0, 400.0)
+    locationAnimatorCoordinator.feedNewPadding(
+      padding,
+      cameraPosition,
+      DEFAULT_TRACKING_PADDING_ANIM_DURATION,
+      null
+    )
+
+    val animator = locationAnimatorCoordinator.animatorArray[ANIMATOR_PADDING]
+    assertTrue(padding.contentEquals(animator.target as DoubleArray))
+    verify { animatorSetProvider.startAnimation(eq(listOf(animator)), any<LinearInterpolator>(), DEFAULT_TRACKING_PADDING_ANIM_DURATION) }
+  }
+
+  @Test
   fun feedNewTiltLevel_animatorsCreated() {
     locationAnimatorCoordinator.feedNewTilt(
       30.0,
@@ -513,6 +555,21 @@ class LocationAnimatorCoordinatorTest {
     locationAnimatorCoordinator.cancelZoomAnimation()
 
     assertFalse(locationAnimatorCoordinator.animatorArray[ANIMATOR_ZOOM].isStarted)
+  }
+
+  @Test
+  fun cancelPaddingAnimators() {
+    locationAnimatorCoordinator.feedNewPadding(
+      doubleArrayOf(100.0, 200.0, 300.0, 400.0),
+      cameraPosition,
+      DEFAULT_TRACKING_PADDING_ANIM_DURATION,
+      null
+    )
+    assertTrue(locationAnimatorCoordinator.animatorArray[ANIMATOR_PADDING].isStarted)
+
+    locationAnimatorCoordinator.cancelPaddingAnimation()
+
+    assertFalse(locationAnimatorCoordinator.animatorArray[ANIMATOR_PADDING].isStarted)
   }
 
   @Test

--- a/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
+++ b/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/location/LocationComponentTest.kt
@@ -31,6 +31,7 @@ import com.mapbox.mapboxsdk.utils.BitmapUtils
 import com.mapbox.mapboxsdk.utils.ColorUtils
 import org.hamcrest.CoreMatchers.*
 import org.junit.*
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.runner.RunWith
@@ -1524,6 +1525,122 @@ class LocationComponentTest : EspressoTest() {
         uiController.loopMainThreadForAtLeast(DEFAULT_TRACKING_TILT_ANIM_DURATION / 2)
 
         assertEquals(30.0 / 2.0, mapboxMap.cameraPosition.tilt, 3.0)
+      }
+    }
+
+    executeComponentTest(componentAction)
+  }
+
+  @Test
+  fun animators_dontPaddingWhileNotTracking() {
+    val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
+      override fun onLocationComponentAction(
+        component: LocationComponent,
+        mapboxMap: MapboxMap,
+        style: Style,
+        uiController: UiController,
+        context: Context
+      ) {
+        component.activateLocationComponent(LocationComponentActivationOptions
+          .builder(context, style)
+          .useDefaultLocationEngine(false)
+          .build())
+        component.isLocationComponentEnabled = true
+        component.cameraMode = CameraMode.NONE
+        val padding = mapboxMap.cameraPosition.padding
+        component.paddingWhileTracking(doubleArrayOf(100.0, 200.0, 300.0, 400.0))
+        uiController.loopMainThreadForAtLeast(DEFAULT_TRACKING_PADDING_ANIM_DURATION)
+        TestingAsyncUtils.waitForLayer(uiController, mapView)
+
+        assertArrayEquals(padding, mapboxMap.cameraPosition.padding, 0.1)
+      }
+    }
+
+    executeComponentTest(componentAction)
+  }
+
+  @Test
+  fun animators_dontPaddingWhileStopped() {
+    val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
+      override fun onLocationComponentAction(
+        component: LocationComponent,
+        mapboxMap: MapboxMap,
+        style: Style,
+        uiController: UiController,
+        context: Context
+      ) {
+        component.activateLocationComponent(LocationComponentActivationOptions
+          .builder(context, style)
+          .useDefaultLocationEngine(false)
+          .build())
+        component.isLocationComponentEnabled = true
+        component.cameraMode = CameraMode.TRACKING
+        val padding = mapboxMap.cameraPosition.padding
+
+        component.onStop()
+        component.paddingWhileTracking(doubleArrayOf(100.0, 200.0, 300.0, 400.0))
+        uiController.loopMainThreadForAtLeast(DEFAULT_TRACKING_PADDING_ANIM_DURATION)
+        TestingAsyncUtils.waitForLayer(uiController, mapView)
+
+        assertArrayEquals(padding, mapboxMap.cameraPosition.padding, 0.1)
+      }
+    }
+
+    executeComponentTest(componentAction)
+  }
+
+  @Test
+  fun animators_dontPaddingWhileTransitioning() {
+    val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
+      override fun onLocationComponentAction(
+        component: LocationComponent,
+        mapboxMap: MapboxMap,
+        style: Style,
+        uiController: UiController,
+        context: Context
+      ) {
+        component.activateLocationComponent(LocationComponentActivationOptions
+          .builder(context, style)
+          .useDefaultLocationEngine(false)
+          .build())
+        component.isLocationComponentEnabled = true
+        component.forceLocationUpdate(location)
+
+        val padding = mapboxMap.cameraPosition.padding
+        component.setCameraMode(CameraMode.TRACKING_GPS, 500L, null, null, null, null)
+        component.paddingWhileTracking(doubleArrayOf(100.0, 200.0, 300.0, 400.0), 1000L)
+        uiController.loopMainThreadForAtLeast(1000L)
+        TestingAsyncUtils.waitForLayer(uiController, mapView)
+
+        assertArrayEquals(padding, mapboxMap.cameraPosition.padding, 0.1)
+      }
+    }
+
+    executeComponentTest(componentAction)
+  }
+
+  @Test
+  fun animators_paddingWhileTracking() {
+    val componentAction = object : LocationComponentAction.OnPerformLocationComponentAction {
+      override fun onLocationComponentAction(
+        component: LocationComponent,
+        mapboxMap: MapboxMap,
+        style: Style,
+        uiController: UiController,
+        context: Context
+      ) {
+        component.activateLocationComponent(LocationComponentActivationOptions
+          .builder(context, style)
+          .useDefaultLocationEngine(false)
+          .build())
+        component.isLocationComponentEnabled = true
+        component.cameraMode = CameraMode.TRACKING
+        val padding = doubleArrayOf(100.0, 200.0, 300.0, 400.0)
+        component.paddingWhileTracking(padding)
+        uiController.loopMainThreadForAtLeast(DEFAULT_TRACKING_PADDING_ANIM_DURATION)
+        TestingAsyncUtils.waitForLayer(uiController, mapView)
+
+        assertTrue(padding.contentEquals(mapboxMap.cameraPosition.padding))
       }
     }
 

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationModesActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationModesActivity.java
@@ -34,6 +34,7 @@ import com.mapbox.mapboxsdk.testapp.R;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 
 public class LocationModesActivity extends AppCompatActivity implements OnMapReadyCallback,
   OnLocationClickListener, OnCameraTrackingChangedListener {
@@ -197,6 +198,28 @@ public class LocationModesActivity extends AppCompatActivity implements OnMapRea
         @Override
         public void onFinish() {
           locationComponent.tiltWhileTracking(60);
+        }
+      });
+      if (locationComponent.getCameraMode() == CameraMode.NONE) {
+
+        Toast.makeText(this, "Not possible to animate - not tracking", Toast.LENGTH_SHORT).show();
+      }
+    } else if (id == R.id.action_component_padding_animation_while_tracking) {
+      Random paddingRandom = new Random();
+      locationComponent.paddingWhileTracking(new double[] {
+          paddingRandom.nextDouble() * 500,
+          paddingRandom.nextDouble() * 500,
+          paddingRandom.nextDouble() * 500,
+          paddingRandom.nextDouble() * 500
+      }, 1000L, new MapboxMap.CancelableCallback() {
+        @Override
+        public void onCancel() {
+          // No impl
+        }
+
+        @Override
+        public void onFinish() {
+          locationComponent.zoomWhileTracking(16);
         }
       });
       if (locationComponent.getCameraMode() == CameraMode.NONE) {

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationModesActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationModesActivity.java
@@ -207,10 +207,10 @@ public class LocationModesActivity extends AppCompatActivity implements OnMapRea
     } else if (id == R.id.action_component_padding_animation_while_tracking) {
       Random paddingRandom = new Random();
       locationComponent.paddingWhileTracking(new double[] {
-          paddingRandom.nextDouble() * 500,
-          paddingRandom.nextDouble() * 500,
-          paddingRandom.nextDouble() * 500,
-          paddingRandom.nextDouble() * 500
+          paddingRandom.nextDouble() * 500 * (paddingRandom.nextBoolean() ? -1 : 1),
+          paddingRandom.nextDouble() * 500 * (paddingRandom.nextBoolean() ? -1 : 1),
+          paddingRandom.nextDouble() * 500 * (paddingRandom.nextBoolean() ? -1 : 1),
+          paddingRandom.nextDouble() * 500 * (paddingRandom.nextBoolean() ? -1 : 1)
       }, 1000L, new MapboxMap.CancelableCallback() {
         @Override
         public void onCancel() {

--- a/MapboxGLAndroidSDKTestApp/src/main/res/menu/menu_location_mode.xml
+++ b/MapboxGLAndroidSDKTestApp/src/main/res/menu/menu_location_mode.xml
@@ -36,4 +36,8 @@
     <item android:id="@+id/action_component_animate_while_tracking"
         android:title="Animate while tracking"
         app:showAsAction="never"/>
+
+    <item android:id="@+id/action_component_padding_animation_while_tracking"
+        android:title="PaddingAnimation while tracking"
+        app:showAsAction="never"/>
 </menu>


### PR DESCRIPTION
`<changelog>Enabled setting padding while keeping the camera tracking mode.</changelog>`

This PR implements `paddingWhileTracking` API so the developer can set a new padding to the mapview while keeping the camera tracking mode.  

<!-- Examples: -->
<!-- `<changelog>Enabled reusing objects with `Projection.getVisibleCoordinateBounds`.</changelog>` -->
<!-- `<changelog>Added an option to set the minimum and maximum pitch of a `Map`.</changelog>`-->
<!-- `<changelog>Introduced `in` expression for testing whether an item exists in an array or a substring exists in a string.</changelog>`
<!-- `<changelog>Significantly improved offline pack download performance by marking resources as used in batches.</changelog>`
<!-- `<changelog>Fixed a bug where non-overlapping symbols would be sorted incorrectly with `SymbolLayer.symbolSortKey`.</changelog>` -->


