### PR TITLE
[deps] update core library to v2.0.0-alpha.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -40,7 +40,7 @@ ext {
             ktlint           : '0.34.0',
             commonsIO        : '2.6',
             mapboxSdkVersions: '1.0.1',
-            mapboxSdkCore    : '1.8.3'
+            mapboxSdkCore    : '2.0.0-alpha.1'
     ]
 
     dependenciesList = [


### PR DESCRIPTION
Bump develop branch to latest pre release of gl-native.
Unblocks testing of develop branch + adding test for https://github.com/mapbox/mapbox-gl-native-android/pull/495.