### PR TITLE
Bump telemetry dependency to 6.1.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
 
     versions = [
             mapboxServices   : '5.3.0',
-            mapboxTelemetry  : '6.0.0',
+            mapboxTelemetry  : '6.1.0',
             mapboxCore       : '3.0.0',
             mapboxGestures   : '0.7.0',
             mapboxAccounts   : '0.7.0',


### PR DESCRIPTION
This PR cherrypicks https://github.com/mapbox/mapbox-gl-native-android/pull/527 to master

`<changelog>Update telemetry to 6.1.0</changelog>`

<!-- Examples: -->
<!-- `<changelog>Enabled reusing objects with `Projection.getVisibleCoordinateBounds`.</changelog>` -->
<!-- `<changelog>Added an option to set the minimum and maximum pitch of a `Map`.</changelog>`-->
<!-- `<changelog>Introduced `in` expression for testing whether an item exists in an array or a substring exists in a string.</changelog>`
<!-- `<changelog>Significantly improved offline pack download performance by marking resources as used in batches.</changelog>`
<!-- `<changelog>Fixed a bug where non-overlapping symbols would be sorted incorrectly with `SymbolLayer.symbolSortKey`.</changelog>` -->


