### PR TITLE
Crash when converting screencoordinate as part of moveBy

### DIFF
--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -526,7 +526,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   /**
    * Add an OnTouchListener which will be call when an event occurs
    *
-   * @param listener
+   * @param listener listener to be called when touch event occurs
    * @return true if listener has been successfully registered
    */
   public boolean addOnTouchListener(OnTouchListener listener) {
@@ -536,7 +536,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   /**
    * Remove an OnTouchListener previously registered
    *
-   * @param listener
+   * @param listener listener to be called when touch event occurs
    * @return true if listener has been successfully unregistered
    */
   public boolean removeOnTouchListener(OnTouchListener listener) {

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -264,7 +264,14 @@ final class NativeMapView implements NativeMap {
     if (checkState("moveBy")) {
       return;
     }
-    nativeMoveBy(dx / pixelRatio, dy / pixelRatio, duration);
+
+    try {
+      nativeMoveBy(dx / pixelRatio, dy / pixelRatio, duration);
+    } catch (java.lang.Error error) {
+      // workaround for latitude must not be NaN issue
+      // which is thrown when gl-native can't convert a screen coordinate to location
+      Logger.d(TAG, "Error when executing NativeMapView#moveBy", error);
+    }
   }
 
   @Override


### PR DESCRIPTION
we use Transform::moveBy for scrolling and fling gestures. There are cases as reported by customers that sometimes NaN value are produced for the latitude value:

```
java.lang.Error: latitude must not be NaN	
at com.mapbox.mapboxsdk.maps.NativeMapView.nativeMoveBy(NativeMapView.java)
at com.mapbox.mapboxsdk.maps.NativeMapView.moveBy(NativeMapView.java:242)
at com.mapbox.mapboxsdk.maps.Transform.moveBy(Transform.java:313)
at com.mapbox.mapboxsdk.maps.MapGestureDetector$MoveGestureListener.onMove(MapGestureDetector.java:494)
```

This happens as part of `screenCoordinateToLatLng` within Transform::moveBy. 

-----


Capturing from @pozdnyakov in an upstream ticket:
```
map transform API is not exception-free. Could this exception be caught and handled on platform side?
```

This PR addresses above comment by wrapping `nativeMoveBy` and logging the occurrence. 