### PR TITLE
Make MapView a LifeCycleObserver on Android's LifeCycle events

### DIFF
--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -19,6 +19,10 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 import androidx.collection.LongSparseArray;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleObserver;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.OnLifecycleEvent;
 
 import com.mapbox.android.gestures.AndroidGesturesManager;
 import com.mapbox.mapboxsdk.MapStrictMode;
@@ -61,7 +65,7 @@ import static com.mapbox.mapboxsdk.maps.widgets.CompassView.TIME_WAIT_IDLE;
  * <strong>Warning:</strong> Please note that you are responsible for getting permission to use the map data,
  * and for ensuring your use adheres to the relevant terms of use.
  */
-public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
+public class MapView extends FrameLayout implements NativeMapView.ViewCallback, LifecycleObserver {
 
   private final MapChangeReceiver mapChangeReceiver = new MapChangeReceiver();
   private final MapCallback mapCallback = new MapCallback();
@@ -376,6 +380,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   /**
    * You must call this method from the parent's Activity#onStart() or Fragment#onStart()
    */
+  @OnLifecycleEvent(Lifecycle.Event.ON_START)
   @UiThread
   public void onStart() {
     if (!isStarted) {
@@ -395,6 +400,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   /**
    * You must call this method from the parent's Activity#onResume() or Fragment#onResume().
    */
+  @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
   @UiThread
   public void onResume() {
     if (mapRenderer != null) {
@@ -405,6 +411,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   /**
    * You must call this method from the parent's Activity#onPause() or Fragment#onPause().
    */
+  @OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)
   @UiThread
   public void onPause() {
     if (mapRenderer != null) {
@@ -415,6 +422,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   /**
    * You must call this method from the parent's Activity#onStop() or Fragment#onStop().
    */
+  @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
   @UiThread
   public void onStop() {
     if (attributionClickListener != null) {
@@ -441,6 +449,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   /**
    * You must call this method from the parent's Activity#onDestroy() or Fragment#onDestroyView().
    */
+  @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
   @UiThread
   public void onDestroy() {
     destroyed = true;
@@ -1452,4 +1461,13 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   public static void setMapStrictModeEnabled(boolean strictModeEnabled) {
     MapStrictMode.setStrictModeEnabled(strictModeEnabled);
   }
+
+  /**
+   * Attachs the view to the LifeCycleOwner so that it can listen to all android lifecycle events and call the necessary mapview lifecycle events.
+   * @param owner Any class that extends LifeCycleOwner e.g. Activity or Fragment.
+   */
+  public void attachLifeCycle(LifecycleOwner owner) {
+    owner.getLifecycle().addObserver(this);
+  }
+
 }

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/SupportMapFragment.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/SupportMapFragment.java
@@ -97,6 +97,7 @@ public class SupportMapFragment extends Fragment implements OnMapReadyCallback {
     super.onCreateView(inflater, container, savedInstanceState);
     Context context = inflater.getContext();
     map = new MapView(context, MapFragmentUtils.resolveArgs(context, getArguments()));
+    map.attachLifeCycle(this);
     return map;
   }
 
@@ -126,32 +127,7 @@ public class SupportMapFragment extends Fragment implements OnMapReadyCallback {
     }
   }
 
-  /**
-   * Called when the fragment is visible for the users.
-   */
-  @Override
-  public void onStart() {
-    super.onStart();
-    map.onStart();
-  }
 
-  /**
-   * Called when the fragment is ready to be interacted with.
-   */
-  @Override
-  public void onResume() {
-    super.onResume();
-    map.onResume();
-  }
-
-  /**
-   * Called when the fragment is pausing.
-   */
-  @Override
-  public void onPause() {
-    super.onPause();
-    map.onPause();
-  }
 
   /**
    * Called when the fragment state needs to be saved.
@@ -164,15 +140,6 @@ public class SupportMapFragment extends Fragment implements OnMapReadyCallback {
     if (map != null) {
       map.onSaveInstanceState(outState);
     }
-  }
-
-  /**
-   * Called when the fragment is no longer visible for the user.
-   */
-  @Override
-  public void onStop() {
-    super.onStop();
-    map.onStop();
   }
 
   /**

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/AnimatedSymbolLayerActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/AnimatedSymbolLayerActivity.java
@@ -6,7 +6,9 @@ import android.animation.TypeEvaluator;
 import android.animation.ValueAnimator;
 import android.graphics.drawable.BitmapDrawable;
 import android.os.Bundle;
+
 import androidx.appcompat.app.AppCompatActivity;
+
 import android.view.animation.AccelerateDecelerateInterpolator;
 import android.view.animation.LinearInterpolator;
 
@@ -74,6 +76,8 @@ public class AnimatedSymbolLayerActivity extends AppCompatActivity {
 
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
+    mapView.attachLifeCycle(this);
+
     mapView.getMapAsync(map -> {
       this.mapboxMap = map;
       map.setStyle(Style.MAPBOX_STREETS, style -> {
@@ -340,30 +344,6 @@ public class AnimatedSymbolLayerActivity extends AppCompatActivity {
   }
 
   @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
-
-  @Override
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
@@ -379,8 +359,6 @@ public class AnimatedSymbolLayerActivity extends AppCompatActivity {
         animator.cancel();
       }
     }
-
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/BulkMarkerActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/BulkMarkerActivity.java
@@ -3,14 +3,17 @@ package com.mapbox.mapboxsdk.testapp.activity.annotation;
 import android.app.ProgressDialog;
 import android.os.AsyncTask;
 import android.os.Bundle;
+
 import androidx.core.view.MenuItemCompat;
 import androidx.appcompat.app.AppCompatActivity;
+
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Spinner;
+
 import com.mapbox.mapboxsdk.annotations.MarkerOptions;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapView;
@@ -18,6 +21,7 @@ import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.testapp.R;
 import com.mapbox.mapboxsdk.testapp.utils.GeoParseUtil;
+
 import timber.log.Timber;
 
 import java.io.IOException;
@@ -45,10 +49,12 @@ public class BulkMarkerActivity extends AppCompatActivity implements AdapterView
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
     mapView.getMapAsync(this::initMap);
+    mapView.attachLifeCycle(this);
+
   }
 
   private void initMap(MapboxMap mapboxMap) {
-    this.mapboxMap =  mapboxMap;
+    this.mapboxMap = mapboxMap;
     mapboxMap.setStyle(Style.MAPBOX_STREETS);
   }
 
@@ -119,30 +125,6 @@ public class BulkMarkerActivity extends AppCompatActivity implements AdapterView
   }
 
   @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
-
-  @Override
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
@@ -154,7 +136,6 @@ public class BulkMarkerActivity extends AppCompatActivity implements AdapterView
     if (progressDialog != null) {
       progressDialog.dismiss();
     }
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/DynamicMarkerChangeActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/DynamicMarkerChangeActivity.java
@@ -1,7 +1,9 @@
 package com.mapbox.mapboxsdk.testapp.activity.annotation;
 
 import android.os.Bundle;
+
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
+
 import androidx.core.content.ContextCompat;
 import androidx.core.content.res.ResourcesCompat;
 import androidx.appcompat.app.AppCompatActivity;
@@ -35,6 +37,7 @@ public class DynamicMarkerChangeActivity extends AppCompatActivity {
     mapView = findViewById(R.id.mapView);
     mapView.setTag(false);
     mapView.onCreate(savedInstanceState);
+    mapView.attachLifeCycle(this);
     mapView.getMapAsync(mapboxMap -> {
       mapboxMap.setStyle(Style.MAPBOX_STREETS);
 
@@ -77,39 +80,9 @@ public class DynamicMarkerChangeActivity extends AppCompatActivity {
   }
 
   @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
-
-  @Override
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/PolygonActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/PolygonActivity.java
@@ -2,8 +2,10 @@ package com.mapbox.mapboxsdk.testapp.activity.annotation;
 
 import android.graphics.Color;
 import android.os.Bundle;
+
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
+
 import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.Toast;
@@ -69,7 +71,7 @@ public class PolygonActivity extends AppCompatActivity implements OnMapReadyCall
     mapView.setId(R.id.mapView);
     mapView.onCreate(savedInstanceState);
     mapView.getMapAsync(this);
-
+    mapView.attachLifeCycle(this);
     setContentView(mapView);
   }
 
@@ -90,39 +92,9 @@ public class PolygonActivity extends AppCompatActivity implements OnMapReadyCall
   }
 
   @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
-
-  @Override
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/PolylineActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/PolylineActivity.java
@@ -2,7 +2,9 @@ package com.mapbox.mapboxsdk.testapp.activity.annotation;
 
 import android.graphics.Color;
 import android.os.Bundle;
+
 import androidx.appcompat.app.AppCompatActivity;
+
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -64,6 +66,7 @@ public class PolylineActivity extends AppCompatActivity {
 
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
+    mapView.attachLifeCycle(this);
     mapView.getMapAsync(mapboxMap -> {
       PolylineActivity.this.mapboxMap = mapboxMap;
       mapboxMap.setStyle(Style.SATELLITE_STREETS);
@@ -128,41 +131,12 @@ public class PolylineActivity extends AppCompatActivity {
   }
 
   @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
-
-  @Override
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
     outState.putParcelableArrayList(STATE_POLYLINE_OPTIONS, polylineOptions);
   }
 
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
-  }
 
   @Override
   public void onLowMemory() {

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/PressForMarkerActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/PressForMarkerActivity.java
@@ -2,8 +2,10 @@ package com.mapbox.mapboxsdk.testapp.activity.annotation;
 
 import android.graphics.PointF;
 import android.os.Bundle;
+
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+
 import android.view.Menu;
 import android.view.MenuItem;
 
@@ -40,6 +42,7 @@ public class PressForMarkerActivity extends AppCompatActivity {
 
     mapView = (MapView) findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
+    mapView.attachLifeCycle(this);
     mapView.getMapAsync(map -> {
       mapboxMap = map;
       resetMap();
@@ -101,36 +104,6 @@ public class PressForMarkerActivity extends AppCompatActivity {
 
     mapView.onSaveInstanceState(outState);
     outState.putParcelableArrayList(STATE_MARKER_LIST, markerList);
-  }
-
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/CameraAnimationTypeActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/CameraAnimationTypeActivity.java
@@ -1,8 +1,10 @@
 package com.mapbox.mapboxsdk.testapp.activity.camera;
 
 import android.os.Bundle;
+
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
+
 import android.view.View;
 import android.widget.Toast;
 
@@ -68,6 +70,7 @@ public class CameraAnimationTypeActivity extends AppCompatActivity implements On
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
     mapView.getMapAsync(this);
+    mapView.attachLifeCycle(this);
   }
 
   @Override
@@ -127,30 +130,6 @@ public class CameraAnimationTypeActivity extends AppCompatActivity implements On
   }
 
   @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
-
-  @Override
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
@@ -162,7 +141,6 @@ public class CameraAnimationTypeActivity extends AppCompatActivity implements On
     if (mapboxMap != null) {
       mapboxMap.removeOnCameraIdleListener(cameraIdleListener);
     }
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/CameraAnimatorActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/CameraAnimatorActivity.java
@@ -5,12 +5,14 @@ import android.animation.AnimatorSet;
 import android.animation.TypeEvaluator;
 import android.animation.ValueAnimator;
 import android.os.Bundle;
+
 import androidx.annotation.NonNull;
 import androidx.collection.LongSparseArray;
 import androidx.interpolator.view.animation.FastOutLinearInInterpolator;
 import androidx.interpolator.view.animation.FastOutSlowInInterpolator;
 import androidx.core.view.animation.PathInterpolatorCompat;
 import androidx.appcompat.app.AppCompatActivity;
+
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -71,6 +73,7 @@ public class CameraAnimatorActivity extends AppCompatActivity implements OnMapRe
     mapView = (MapView) findViewById(R.id.mapView);
     if (mapView != null) {
       mapView.onCreate(savedInstanceState);
+      mapView.attachLifeCycle(this);
       mapView.getMapAsync(this);
     }
   }
@@ -214,28 +217,10 @@ public class CameraAnimatorActivity extends AppCompatActivity implements OnMapRe
   // MapView lifecycle
   //
 
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
 
   @Override
   protected void onStop() {
     super.onStop();
-    mapView.onStop();
     for (int i = 0; i < animators.size(); i++) {
       animators.get(animators.keyAt(i)).cancel();
     }
@@ -248,12 +233,6 @@ public class CameraAnimatorActivity extends AppCompatActivity implements OnMapRe
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/CameraPositionActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/CameraPositionActivity.java
@@ -3,13 +3,17 @@ package com.mapbox.mapboxsdk.testapp.activity.camera;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
+
 import androidx.annotation.IdRes;
 import androidx.annotation.NonNull;
+
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
+
 import androidx.fragment.app.FragmentActivity;
 import androidx.core.content.ContextCompat;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
+
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.SeekBar;
@@ -24,6 +28,7 @@ import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.testapp.R;
+
 import timber.log.Timber;
 
 import static com.mapbox.mapboxsdk.constants.GeometryConstants.MAX_LATITUDE;
@@ -53,6 +58,7 @@ public class CameraPositionActivity extends FragmentActivity implements OnMapRea
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
     mapView.getMapAsync(this);
+    mapView.attachLifeCycle(this);
   }
 
   @Override
@@ -106,36 +112,11 @@ public class CameraPositionActivity extends FragmentActivity implements OnMapRea
   }
 
   @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
-
-  @Override
   protected void onDestroy() {
     super.onDestroy();
     if (mapboxMap != null) {
       mapboxMap.removeOnMapLongClickListener(this);
     }
-    mapView.onDestroy();
   }
 
   @Override
@@ -249,7 +230,7 @@ public class CameraPositionActivity extends FragmentActivity implements OnMapRea
 
       if (latitude < MIN_LATITUDE || latitude > MAX_LATITUDE) {
         Toast.makeText(dialogContent.getContext(), "latitude value must be set "
-                + " between " + MIN_LATITUDE + " and " + MAX_LATITUDE,
+            + " between " + MIN_LATITUDE + " and " + MAX_LATITUDE,
           Toast.LENGTH_SHORT).show();
         return;
       }

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/GestureDetectorActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/GestureDetectorActivity.java
@@ -3,6 +3,7 @@ package com.mapbox.mapboxsdk.testapp.activity.camera;
 import android.graphics.Typeface;
 import android.os.Bundle;
 import android.os.Handler;
+
 import androidx.annotation.ColorInt;
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
@@ -11,6 +12,7 @@ import androidx.core.content.ContextCompat;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
+
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -68,6 +70,7 @@ public class GestureDetectorActivity extends AppCompatActivity {
 
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
+    mapView.attachLifeCycle(this);
     mapView.getMapAsync(mapboxMap -> {
       GestureDetectorActivity.this.mapboxMap = mapboxMap;
       mapboxMap.setStyle(Style.MAPBOX_STREETS);
@@ -82,40 +85,9 @@ public class GestureDetectorActivity extends AppCompatActivity {
   }
 
   @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    gestureAlertsAdapter.cancelUpdates();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
-
-  @Override
   public void onLowMemory() {
     super.onLowMemory();
     mapView.onLowMemory();
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
   @Override
@@ -379,7 +351,7 @@ public class GestureDetectorActivity extends AppCompatActivity {
 
   private static class GestureAlert {
     @Retention(SOURCE)
-    @IntDef( {TYPE_NONE, TYPE_START, TYPE_PROGRESS, TYPE_END, TYPE_OTHER})
+    @IntDef({TYPE_NONE, TYPE_START, TYPE_PROGRESS, TYPE_END, TYPE_OTHER})
     @interface Type {
     }
 

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/ManualZoomActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/ManualZoomActivity.java
@@ -2,7 +2,9 @@ package com.mapbox.mapboxsdk.testapp.activity.camera;
 
 import android.graphics.Point;
 import android.os.Bundle;
+
 import androidx.appcompat.app.AppCompatActivity;
+
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -32,6 +34,7 @@ public class ManualZoomActivity extends AppCompatActivity {
 
     mapView = (MapView) findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
+    mapView.attachLifeCycle(this);
     mapView.getMapAsync(mapboxMap -> {
       ManualZoomActivity.this.mapboxMap = mapboxMap;
       mapboxMap.setStyle(new Style.Builder().fromUri(Style.SATELLITE));
@@ -77,39 +80,9 @@ public class ManualZoomActivity extends AppCompatActivity {
   }
 
   @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
-
-  @Override
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/MaxMinZoomActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/MaxMinZoomActivity.java
@@ -1,6 +1,7 @@
 package com.mapbox.mapboxsdk.testapp.activity.camera;
 
 import android.os.Bundle;
+
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -39,7 +40,7 @@ public class MaxMinZoomActivity extends AppCompatActivity implements OnMapReadyC
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
     mapView.getMapAsync(this);
-
+    mapView.attachLifeCycle(this);
     mapView.addOnDidFinishLoadingStyleListener(() -> Timber.d("Style Loaded"));
   }
 
@@ -50,30 +51,6 @@ public class MaxMinZoomActivity extends AppCompatActivity implements OnMapReadyC
     mapboxMap.setMinZoomPreference(3);
     mapboxMap.setMaxZoomPreference(5);
     mapboxMap.addOnMapClickListener(clickListener);
-  }
-
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
   }
 
   @Override
@@ -88,7 +65,6 @@ public class MaxMinZoomActivity extends AppCompatActivity implements OnMapReadyC
     if (mapboxMap != null) {
       mapboxMap.removeOnMapClickListener(clickListener);
     }
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/ScrollByActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/ScrollByActivity.java
@@ -57,6 +57,7 @@ public class ScrollByActivity extends AppCompatActivity implements OnMapReadyCal
     mapView.setTag(true);
     mapView.onCreate(savedInstanceState);
     mapView.getMapAsync(this);
+    mapView.attachLifeCycle(this);
   }
 
   @Override
@@ -75,40 +76,11 @@ public class ScrollByActivity extends AppCompatActivity implements OnMapReadyCal
     );
   }
 
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
 
   @Override
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/customlayer/CustomLayerActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/customlayer/CustomLayerActivity.java
@@ -1,11 +1,15 @@
 package com.mapbox.mapboxsdk.testapp.activity.customlayer;
 
 import android.os.Bundle;
+
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
+
 import androidx.core.content.ContextCompat;
 import androidx.appcompat.app.AppCompatActivity;
+
 import android.view.Menu;
 import android.view.MenuItem;
+
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapView;
@@ -36,6 +40,7 @@ public class CustomLayerActivity extends AppCompatActivity {
 
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
+    mapView.attachLifeCycle(this);
     mapView.getMapAsync(map -> {
       mapboxMap = map;
       mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(new LatLng(39.91448, -243.60947), 10));
@@ -74,39 +79,9 @@ public class CustomLayerActivity extends AppCompatActivity {
   }
 
   @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
-
-  @Override
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/espresso/DeviceIndependentTestActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/espresso/DeviceIndependentTestActivity.java
@@ -1,8 +1,10 @@
 package com.mapbox.mapboxsdk.testapp.activity.espresso;
 
 import android.os.Bundle;
+
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
+
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
@@ -23,6 +25,7 @@ public class DeviceIndependentTestActivity extends AppCompatActivity implements 
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
     mapView.getMapAsync(this);
+    mapView.attachLifeCycle(this);
   }
 
   @Override
@@ -35,29 +38,6 @@ public class DeviceIndependentTestActivity extends AppCompatActivity implements 
     return mapboxMap;
   }
 
-  @Override
-  public void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  public void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
 
   @Override
   protected void onSaveInstanceState(Bundle outState) {
@@ -65,11 +45,6 @@ public class DeviceIndependentTestActivity extends AppCompatActivity implements 
     mapView.onSaveInstanceState(outState);
   }
 
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
-  }
 
   @Override
   public void onLowMemory() {

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/espresso/EspressoTestActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/espresso/EspressoTestActivity.java
@@ -1,7 +1,9 @@
 package com.mapbox.mapboxsdk.testapp.activity.espresso;
 
 import android.os.Bundle;
+
 import androidx.appcompat.app.AppCompatActivity;
+
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.testapp.R;
@@ -20,42 +22,13 @@ public class EspressoTestActivity extends AppCompatActivity {
     setContentView(R.layout.activity_espresso_test);
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
-  }
-
-  @Override
-  public void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  public void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
+    mapView.attachLifeCycle(this);
   }
 
   @Override
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/espresso/PixelTestActivity.kt
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/espresso/PixelTestActivity.kt
@@ -13,54 +13,31 @@ import com.mapbox.mapboxsdk.testapp.R
  */
 class PixelTestActivity : AppCompatActivity(), OnMapReadyCallback {
 
-    lateinit var mapView: MapView
-    lateinit var mapboxMap: MapboxMap
+  lateinit var mapView: MapView
+  lateinit var mapboxMap: MapboxMap
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_pixel_test)
-        mapView = findViewById(R.id.mapView)
-        mapView.onCreate(savedInstanceState)
-        mapView.getMapAsync(this)
-    }
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContentView(R.layout.activity_pixel_test)
+    mapView = findViewById(R.id.mapView)
+    mapView.onCreate(savedInstanceState)
+    mapView.getMapAsync(this)
+    mapView.attachLifeCycle(this)
+  }
 
-    override fun onMapReady(map: MapboxMap) {
-        mapboxMap = map
-        mapboxMap.setStyle(Style.MAPBOX_STREETS)
-    }
+  override fun onMapReady(map: MapboxMap) {
+    mapboxMap = map
+    mapboxMap.setStyle(Style.MAPBOX_STREETS)
+  }
 
-    public override fun onResume() {
-        super.onResume()
-        mapView.onResume()
-    }
 
-    override fun onStart() {
-        super.onStart()
-        mapView.onStart()
-    }
+  override fun onSaveInstanceState(outState: Bundle) {
+    super.onSaveInstanceState(outState)
+    mapView.onSaveInstanceState(outState)
+  }
 
-    public override fun onPause() {
-        super.onPause()
-        mapView.onPause()
-    }
-
-    override fun onStop() {
-        super.onStop()
-        mapView.onStop()
-    }
-
-    override fun onSaveInstanceState(outState: Bundle) {
-        super.onSaveInstanceState(outState)
-        mapView.onSaveInstanceState(outState)
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        mapView.onDestroy()
-    }
-
-    override fun onLowMemory() {
-        super.onLowMemory()
-        mapView.onLowMemory()
-    }
+  override fun onLowMemory() {
+    super.onLowMemory()
+    mapView.onLowMemory()
+  }
 }

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/feature/QueryRenderedFeaturesBoxCountActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/feature/QueryRenderedFeaturesBoxCountActivity.java
@@ -3,10 +3,13 @@ package com.mapbox.mapboxsdk.testapp.activity.feature;
 import android.graphics.PointF;
 import android.graphics.RectF;
 import android.os.Bundle;
+
 import androidx.appcompat.app.AppCompatActivity;
+
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.Toast;
+
 import com.google.gson.JsonElement;
 import com.mapbox.geojson.Feature;
 import com.mapbox.mapboxsdk.maps.MapView;
@@ -14,6 +17,7 @@ import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.testapp.R;
 import com.mapbox.mapboxsdk.testapp.utils.NavUtils;
+
 import timber.log.Timber;
 
 import java.util.List;
@@ -60,6 +64,8 @@ public class QueryRenderedFeaturesBoxCountActivity extends AppCompatActivity {
         debugOutput(features);
       });
     });
+
+    mapView.attachLifeCycle(this);
   }
 
   private void debugOutput(List<Feature> features) {
@@ -89,8 +95,6 @@ public class QueryRenderedFeaturesBoxCountActivity extends AppCompatActivity {
   @Override
   protected void onStart() {
     super.onStart();
-    mapView.onStart();
-
     if (mapboxMap != null) {
       // Regression test for #14394
       mapboxMap.queryRenderedFeatures(new PointF(0, 0));
@@ -98,33 +102,9 @@ public class QueryRenderedFeaturesBoxCountActivity extends AppCompatActivity {
   }
 
   @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
-
-  @Override
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/feature/QueryRenderedFeaturesBoxHighlightActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/feature/QueryRenderedFeaturesBoxHighlightActivity.java
@@ -80,35 +80,16 @@ public class QueryRenderedFeaturesBoxHighlightActivity extends AppCompatActivity
         .withLayer(layer)
       );
     });
+    mapView.attachLifeCycle(this);
   }
 
   public MapboxMap getMapboxMap() {
     return mapboxMap;
   }
 
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
 
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
 
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
 
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
 
   @Override
   protected void onSaveInstanceState(Bundle outState) {
@@ -116,11 +97,6 @@ public class QueryRenderedFeaturesBoxHighlightActivity extends AppCompatActivity
     mapView.onSaveInstanceState(outState);
   }
 
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
-  }
 
   @Override
   public void onLowMemory() {

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/feature/QueryRenderedFeaturesBoxSymbolCountActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/feature/QueryRenderedFeaturesBoxSymbolCountActivity.java
@@ -95,46 +95,19 @@ public class QueryRenderedFeaturesBoxSymbolCountActivity extends AppCompatActivi
         toast.show();
       });
     });
+
+    mapView.attachLifeCycle(this);
   }
 
   public MapboxMap getMapboxMap() {
     return mapboxMap;
   }
 
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
 
   @Override
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/feature/QueryRenderedFeaturesPropertiesActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/feature/QueryRenderedFeaturesPropertiesActivity.java
@@ -81,6 +81,7 @@ public class QueryRenderedFeaturesPropertiesActivity extends AppCompatActivity {
         mapboxMap.addOnMapClickListener(mapClickListener);
       });
     });
+    mapView.attachLifeCycle(this);
   }
 
   private void debugOutput(List<Feature> features) {
@@ -138,29 +139,8 @@ public class QueryRenderedFeaturesPropertiesActivity extends AppCompatActivity {
     return mapboxMap;
   }
 
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
 
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
 
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
 
   @Override
   protected void onSaveInstanceState(Bundle outState) {
@@ -168,14 +148,6 @@ public class QueryRenderedFeaturesPropertiesActivity extends AppCompatActivity {
     mapView.onSaveInstanceState(outState);
   }
 
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    if (mapboxMap != null) {
-      mapboxMap.removeOnMapClickListener(mapClickListener);
-    }
-    mapView.onDestroy();
-  }
 
   @Override
   public void onLowMemory() {

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/feature/QuerySourceFeaturesActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/feature/QuerySourceFeaturesActivity.java
@@ -45,6 +45,7 @@ public class QuerySourceFeaturesActivity extends AppCompatActivity {
       mapboxMap.getStyle(this::initStyle);
       mapboxMap.setStyle(Style.MAPBOX_STREETS);
     });
+    mapView.attachLifeCycle(this);
   }
 
   private void initStyle(Style style) {
@@ -90,40 +91,13 @@ public class QuerySourceFeaturesActivity extends AppCompatActivity {
     });
   }
 
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
 
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
 
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
 
   @Override
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/imagegenerator/PrintActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/imagegenerator/PrintActivity.java
@@ -2,9 +2,12 @@ package com.mapbox.mapboxsdk.testapp.activity.imagegenerator;
 
 import android.graphics.Bitmap;
 import android.os.Bundle;
+
 import androidx.print.PrintHelper;
 import androidx.appcompat.app.AppCompatActivity;
+
 import android.view.View;
+
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.Style;
@@ -26,6 +29,7 @@ public class PrintActivity extends AppCompatActivity implements MapboxMap.Snapsh
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
     mapView.getMapAsync(this::initMap);
+    mapView.attachLifeCycle(this);
 
     final View fab = findViewById(R.id.fab);
     if (fab != null) {
@@ -49,40 +53,11 @@ public class PrintActivity extends AppCompatActivity implements MapboxMap.Snapsh
     photoPrinter.printBitmap("map.jpg - mapbox print job", snapshot);
   }
 
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
 
   @Override
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/imagegenerator/SnapshotActivity.kt
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/imagegenerator/SnapshotActivity.kt
@@ -36,6 +36,7 @@ class SnapshotActivity : AppCompatActivity(), OnMapReadyCallback {
     setContentView(R.layout.activity_snapshot)
     mapView.onCreate(savedInstanceState)
     mapView.getMapAsync(this)
+    mapView.attachLifeCycle(this)
   }
 
   override fun onMapReady(map: MapboxMap) {
@@ -43,28 +44,15 @@ class SnapshotActivity : AppCompatActivity(), OnMapReadyCallback {
     mapboxMap.setStyle(Style.Builder().fromUri(Style.OUTDOORS)) { mapView.addOnDidFinishRenderingFrameListener(idleListener) }
   }
 
-  override fun onStart() {
-    super.onStart()
-    mapView.onStart()
-  }
 
-  override fun onResume() {
-    super.onResume()
-    mapView.onResume()
-  }
 
   override fun onPause() {
     super.onPause()
     mapboxMap.snapshot {
       Timber.e("Regression test for https://github.com/mapbox/mapbox-gl-native/pull/11358")
     }
-    mapView.onPause()
   }
 
-  override fun onStop() {
-    super.onStop()
-    mapView.onStop()
-  }
 
   public override fun onSaveInstanceState(outState: Bundle) {
     super.onSaveInstanceState(outState)
@@ -79,7 +67,6 @@ class SnapshotActivity : AppCompatActivity(), OnMapReadyCallback {
   public override fun onDestroy() {
     super.onDestroy()
     mapView.removeOnDidFinishRenderingFrameListener(idleListener)
-    mapView.onDestroy()
   }
 
   companion object {

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/infowindow/DynamicInfoWindowAdapterActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/infowindow/DynamicInfoWindowAdapterActivity.java
@@ -2,9 +2,11 @@ package com.mapbox.mapboxsdk.testapp.activity.infowindow;
 
 import android.graphics.Color;
 import android.os.Bundle;
+
 import androidx.annotation.NonNull;
 import androidx.core.content.res.ResourcesCompat;
 import androidx.appcompat.app.AppCompatActivity;
+
 import android.widget.TextView;
 
 import com.mapbox.mapboxsdk.annotations.InfoWindow;
@@ -65,6 +67,7 @@ public class DynamicInfoWindowAdapterActivity extends AppCompatActivity implemen
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
     mapView.getMapAsync(this);
+    mapView.attachLifeCycle(this);
   }
 
   @Override
@@ -111,29 +114,6 @@ public class DynamicInfoWindowAdapterActivity extends AppCompatActivity implemen
     });
   }
 
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
 
   @Override
   protected void onSaveInstanceState(Bundle outState) {
@@ -147,7 +127,6 @@ public class DynamicInfoWindowAdapterActivity extends AppCompatActivity implemen
     if (mapboxMap != null) {
       mapboxMap.removeOnMapClickListener(mapClickListener);
     }
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/infowindow/InfoWindowActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/infowindow/InfoWindowActivity.java
@@ -1,8 +1,10 @@
 package com.mapbox.mapboxsdk.testapp.activity.infowindow;
 
 import android.os.Bundle;
+
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
+
 import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.Toast;
@@ -59,6 +61,7 @@ public class InfoWindowActivity extends AppCompatActivity
     mapView = (MapView) findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
     mapView.getMapAsync(this);
+    mapView.attachLifeCycle(this);
   }
 
   @Override
@@ -131,30 +134,6 @@ public class InfoWindowActivity extends AppCompatActivity
   }
 
   @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
-
-  @Override
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
@@ -166,7 +145,6 @@ public class InfoWindowActivity extends AppCompatActivity
     if (mapboxMap != null) {
       mapboxMap.removeOnMapLongClickListener(mapLongClickListener);
     }
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/infowindow/InfoWindowAdapterActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/infowindow/InfoWindowAdapterActivity.java
@@ -2,8 +2,10 @@ package com.mapbox.mapboxsdk.testapp.activity.infowindow;
 
 import android.graphics.Color;
 import android.os.Bundle;
+
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
+
 import android.view.View;
 import android.widget.TextView;
 
@@ -33,6 +35,7 @@ public class InfoWindowAdapterActivity extends AppCompatActivity {
 
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
+    mapView.attachLifeCycle(this);
     mapView.getMapAsync(map -> {
       mapboxMap = map;
       map.setStyle(Style.MAPBOX_STREETS, style -> {
@@ -85,39 +88,9 @@ public class InfoWindowAdapterActivity extends AppCompatActivity {
   }
 
   @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
-
-  @Override
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/BasicLocationPulsingCircleActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/BasicLocationPulsingCircleActivity.java
@@ -53,6 +53,7 @@ public class BasicLocationPulsingCircleActivity extends AppCompatActivity implem
       lastLocation = savedInstanceState.getParcelable(SAVED_STATE_LOCATION);
     }
     mapView.onCreate(savedInstanceState);
+    mapView.attachLifeCycle(this);
 
     checkPermissions();
   }
@@ -66,12 +67,12 @@ public class BasicLocationPulsingCircleActivity extends AppCompatActivity implem
       locationComponent = mapboxMap.getLocationComponent();
 
       LocationComponentOptions locationComponentOptions =
-          LocationComponentOptions.builder(BasicLocationPulsingCircleActivity.this)
-              .pulseEnabled(true)
-              .build();
+        LocationComponentOptions.builder(BasicLocationPulsingCircleActivity.this)
+          .pulseEnabled(true)
+          .build();
 
       LocationComponentActivationOptions locationComponentActivationOptions =
-          buildLocationComponentActivationOptions(style,locationComponentOptions);
+        buildLocationComponentActivationOptions(style, locationComponentOptions);
 
       locationComponent.activateLocationComponent(locationComponentActivationOptions);
       locationComponent.setLocationComponentEnabled(true);
@@ -82,16 +83,16 @@ public class BasicLocationPulsingCircleActivity extends AppCompatActivity implem
 
   private LocationComponentActivationOptions buildLocationComponentActivationOptions(@NonNull Style style,
                                                                                      @NonNull LocationComponentOptions
-                                                                                         locationComponentOptions) {
+                                                                                       locationComponentOptions) {
     return LocationComponentActivationOptions
-        .builder(this, style)
-        .locationComponentOptions(locationComponentOptions)
-        .useDefaultLocationEngine(true)
-        .locationEngineRequest(new LocationEngineRequest.Builder(750)
-            .setFastestInterval(750)
-            .setPriority(LocationEngineRequest.PRIORITY_HIGH_ACCURACY)
-            .build())
-        .build();
+      .builder(this, style)
+      .locationComponentOptions(locationComponentOptions)
+      .useDefaultLocationEngine(true)
+      .locationEngineRequest(new LocationEngineRequest.Builder(750)
+        .setFastestInterval(750)
+        .setPriority(LocationEngineRequest.PRIORITY_HIGH_ACCURACY)
+        .build())
+      .build();
   }
 
   @Override
@@ -119,15 +120,15 @@ public class BasicLocationPulsingCircleActivity extends AppCompatActivity implem
       return true;
     } else if (id == R.id.action_stop_pulsing) {
       locationComponent.applyStyle(LocationComponentOptions.builder(
-          BasicLocationPulsingCircleActivity.this)
-          .pulseEnabled(false)
-          .build());
+        BasicLocationPulsingCircleActivity.this)
+        .pulseEnabled(false)
+        .build());
       return true;
     } else if (id == R.id.action_start_pulsing) {
       locationComponent.applyStyle(LocationComponentOptions.builder(
-          BasicLocationPulsingCircleActivity.this)
-          .pulseEnabled(true)
-          .build());
+        BasicLocationPulsingCircleActivity.this)
+        .pulseEnabled(true)
+        .build());
       return true;
     }
     return super.onOptionsItemSelected(item);
@@ -145,7 +146,7 @@ public class BasicLocationPulsingCircleActivity extends AppCompatActivity implem
         @Override
         public void onExplanationNeeded(List<String> permissionsToExplain) {
           Toast.makeText(BasicLocationPulsingCircleActivity.this, "You need to accept location permissions.",
-              Toast.LENGTH_SHORT).show();
+            Toast.LENGTH_SHORT).show();
         }
 
         @Override
@@ -167,30 +168,6 @@ public class BasicLocationPulsingCircleActivity extends AppCompatActivity implem
     permissionsManager.onRequestPermissionsResult(requestCode, permissions, grantResults);
   }
 
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
-
   @SuppressLint("MissingPermission")
   @Override
   protected void onSaveInstanceState(Bundle outState) {
@@ -199,12 +176,6 @@ public class BasicLocationPulsingCircleActivity extends AppCompatActivity implem
     if (locationComponent != null) {
       outState.putParcelable(SAVED_STATE_LOCATION, locationComponent.getLastKnownLocation());
     }
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/CustomizedLocationPulsingCircleActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/CustomizedLocationPulsingCircleActivity.java
@@ -48,7 +48,7 @@ public class CustomizedLocationPulsingCircleActivity extends AppCompatActivity i
   private static final float DEFAULT_LOCATION_CIRCLE_PULSE_RADIUS = 35;
   private static final float DEFAULT_LOCATION_CIRCLE_PULSE_ALPHA = .55f;
   private static final Interpolator DEFAULT_LOCATION_CIRCLE_INTERPOLATOR_PULSE_MODE
-      = new DecelerateInterpolator();
+    = new DecelerateInterpolator();
   private static final boolean DEFAULT_LOCATION_CIRCLE_PULSE_FADE_MODE = true;
   //endregion
 
@@ -87,7 +87,7 @@ public class CustomizedLocationPulsingCircleActivity extends AppCompatActivity i
 
     pulsingCircleDurationButton = findViewById(R.id.button_location_circle_duration);
     pulsingCircleDurationButton.setText(String.format("%sms",
-        String.valueOf(LOCATION_CIRCLE_PULSE_DURATION)));
+      String.valueOf(LOCATION_CIRCLE_PULSE_DURATION)));
     pulsingCircleDurationButton.setOnClickListener(v -> {
       if (locationComponent == null) {
         return;
@@ -104,7 +104,7 @@ public class CustomizedLocationPulsingCircleActivity extends AppCompatActivity i
     });
 
     mapView.onCreate(savedInstanceState);
-
+    mapView.attachLifeCycle(this);
     checkPermissions();
   }
 
@@ -117,14 +117,14 @@ public class CustomizedLocationPulsingCircleActivity extends AppCompatActivity i
       locationComponent = mapboxMap.getLocationComponent();
 
       LocationComponentOptions locationComponentOptions =
-          buildLocationComponentOptions(
-              LOCATION_CIRCLE_PULSE_COLOR,
-              LOCATION_CIRCLE_PULSE_DURATION)
-              .pulseEnabled(true)
-              .build();
+        buildLocationComponentOptions(
+          LOCATION_CIRCLE_PULSE_COLOR,
+          LOCATION_CIRCLE_PULSE_DURATION)
+          .pulseEnabled(true)
+          .build();
 
       LocationComponentActivationOptions locationComponentActivationOptions =
-          buildLocationComponentActivationOptions(style,locationComponentOptions);
+        buildLocationComponentActivationOptions(style, locationComponentOptions);
 
       locationComponent.activateLocationComponent(locationComponentActivationOptions);
       locationComponent.setLocationComponentEnabled(true);
@@ -138,38 +138,38 @@ public class CustomizedLocationPulsingCircleActivity extends AppCompatActivity i
   ) {
     currentPulseDuration = pulsingCircleDuration;
     return LocationComponentOptions.builder(this)
-        .layerBelow(LAYER_BELOW_ID)
-        .pulseFadeEnabled(DEFAULT_LOCATION_CIRCLE_PULSE_FADE_MODE)
-        .pulseInterpolator(DEFAULT_LOCATION_CIRCLE_INTERPOLATOR_PULSE_MODE)
-        .pulseColor(pulsingCircleColor)
-        .pulseAlpha(DEFAULT_LOCATION_CIRCLE_PULSE_ALPHA)
-        .pulseSingleDuration(pulsingCircleDuration)
-        .pulseMaxRadius(DEFAULT_LOCATION_CIRCLE_PULSE_RADIUS);
+      .layerBelow(LAYER_BELOW_ID)
+      .pulseFadeEnabled(DEFAULT_LOCATION_CIRCLE_PULSE_FADE_MODE)
+      .pulseInterpolator(DEFAULT_LOCATION_CIRCLE_INTERPOLATOR_PULSE_MODE)
+      .pulseColor(pulsingCircleColor)
+      .pulseAlpha(DEFAULT_LOCATION_CIRCLE_PULSE_ALPHA)
+      .pulseSingleDuration(pulsingCircleDuration)
+      .pulseMaxRadius(DEFAULT_LOCATION_CIRCLE_PULSE_RADIUS);
   }
 
   @SuppressLint("MissingPermission")
   private void setNewLocationComponentOptions(float newPulsingDuration,
                                               int newPulsingColor) {
     mapboxMap.getStyle(style -> locationComponent.applyStyle(
-        buildLocationComponentOptions(
-            newPulsingColor,
-            newPulsingDuration)
-            .pulseEnabled(true)
-            .build()));
+      buildLocationComponentOptions(
+        newPulsingColor,
+        newPulsingDuration)
+        .pulseEnabled(true)
+        .build()));
   }
 
   private LocationComponentActivationOptions buildLocationComponentActivationOptions(
-      @NonNull Style style,
-      @NonNull LocationComponentOptions locationComponentOptions) {
+    @NonNull Style style,
+    @NonNull LocationComponentOptions locationComponentOptions) {
     return LocationComponentActivationOptions
-        .builder(this, style)
-        .locationComponentOptions(locationComponentOptions)
-        .useDefaultLocationEngine(true)
-        .locationEngineRequest(new LocationEngineRequest.Builder(750)
-            .setFastestInterval(750)
-            .setPriority(LocationEngineRequest.PRIORITY_HIGH_ACCURACY)
-            .build())
-        .build();
+      .builder(this, style)
+      .locationComponentOptions(locationComponentOptions)
+      .useDefaultLocationEngine(true)
+      .locationEngineRequest(new LocationEngineRequest.Builder(750)
+        .setFastestInterval(750)
+        .setPriority(LocationEngineRequest.PRIORITY_HIGH_ACCURACY)
+        .build())
+      .build();
   }
 
   @Override
@@ -197,16 +197,16 @@ public class CustomizedLocationPulsingCircleActivity extends AppCompatActivity i
       return true;
     } else if (id == R.id.action_stop_pulsing) {
       locationComponent.applyStyle(LocationComponentOptions.builder(
-          CustomizedLocationPulsingCircleActivity.this)
-          .pulseEnabled(false)
-          .build());
+        CustomizedLocationPulsingCircleActivity.this)
+        .pulseEnabled(false)
+        .build());
       return true;
     } else if (id == R.id.action_start_pulsing) {
       locationComponent.applyStyle(buildLocationComponentOptions(
-          LOCATION_CIRCLE_PULSE_COLOR,
-          LOCATION_CIRCLE_PULSE_DURATION)
-          .pulseEnabled(true)
-          .build());
+        LOCATION_CIRCLE_PULSE_COLOR,
+        LOCATION_CIRCLE_PULSE_DURATION)
+        .pulseEnabled(true)
+        .build());
       return true;
     }
     return super.onOptionsItemSelected(item);
@@ -224,7 +224,7 @@ public class CustomizedLocationPulsingCircleActivity extends AppCompatActivity i
         @Override
         public void onExplanationNeeded(List<String> permissionsToExplain) {
           Toast.makeText(CustomizedLocationPulsingCircleActivity.this, "You need to accept location permissions.",
-              Toast.LENGTH_SHORT).show();
+            Toast.LENGTH_SHORT).show();
         }
 
         @Override
@@ -246,7 +246,7 @@ public class CustomizedLocationPulsingCircleActivity extends AppCompatActivity i
     modes.add(String.format("%sms", String.valueOf(SECOND_LOCATION_CIRCLE_PULSE_DURATION_MS)));
     modes.add(String.format("%sms", String.valueOf(THIRD_LOCATION_CIRCLE_PULSE_DURATION_MS)));
     ArrayAdapter<String> profileAdapter = new ArrayAdapter<>(this,
-        android.R.layout.simple_list_item_1, modes);
+      android.R.layout.simple_list_item_1, modes);
     ListPopupWindow listPopup = new ListPopupWindow(this);
     listPopup.setAdapter(profileAdapter);
     listPopup.setAnchorView(pulsingCircleDurationButton);
@@ -254,15 +254,15 @@ public class CustomizedLocationPulsingCircleActivity extends AppCompatActivity i
       String selectedMode = modes.get(position);
       pulsingCircleDurationButton.setText(selectedMode);
       if (selectedMode.contentEquals(String.format("%sms",
-          String.valueOf(DEFAULT_LOCATION_CIRCLE_PULSE_DURATION_MS)))) {
+        String.valueOf(DEFAULT_LOCATION_CIRCLE_PULSE_DURATION_MS)))) {
         LOCATION_CIRCLE_PULSE_DURATION = DEFAULT_LOCATION_CIRCLE_PULSE_DURATION_MS;
         setNewLocationComponentOptions(DEFAULT_LOCATION_CIRCLE_PULSE_DURATION_MS, LOCATION_CIRCLE_PULSE_COLOR);
       } else if (selectedMode.contentEquals(String.format("%sms",
-          String.valueOf(SECOND_LOCATION_CIRCLE_PULSE_DURATION_MS)))) {
+        String.valueOf(SECOND_LOCATION_CIRCLE_PULSE_DURATION_MS)))) {
         LOCATION_CIRCLE_PULSE_DURATION = SECOND_LOCATION_CIRCLE_PULSE_DURATION_MS;
         setNewLocationComponentOptions(SECOND_LOCATION_CIRCLE_PULSE_DURATION_MS, LOCATION_CIRCLE_PULSE_COLOR);
       } else if (selectedMode.contentEquals(String.format("%sms",
-          String.valueOf(THIRD_LOCATION_CIRCLE_PULSE_DURATION_MS)))) {
+        String.valueOf(THIRD_LOCATION_CIRCLE_PULSE_DURATION_MS)))) {
         LOCATION_CIRCLE_PULSE_DURATION = THIRD_LOCATION_CIRCLE_PULSE_DURATION_MS;
         setNewLocationComponentOptions(THIRD_LOCATION_CIRCLE_PULSE_DURATION_MS, LOCATION_CIRCLE_PULSE_COLOR);
       }
@@ -278,7 +278,7 @@ public class CustomizedLocationPulsingCircleActivity extends AppCompatActivity i
     trackingTypes.add("Green");
     trackingTypes.add("Gray");
     ArrayAdapter<String> profileAdapter = new ArrayAdapter<>(this,
-        android.R.layout.simple_list_item_1, trackingTypes);
+      android.R.layout.simple_list_item_1, trackingTypes);
     ListPopupWindow listPopup = new ListPopupWindow(this);
     listPopup.setAdapter(profileAdapter);
     listPopup.setAnchorView(pulsingCircleColorButton);
@@ -310,29 +310,6 @@ public class CustomizedLocationPulsingCircleActivity extends AppCompatActivity i
     permissionsManager.onRequestPermissionsResult(requestCode, permissions, grantResults);
   }
 
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
 
   @SuppressLint("MissingPermission")
   @Override
@@ -346,11 +323,6 @@ public class CustomizedLocationPulsingCircleActivity extends AppCompatActivity i
     }
   }
 
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
-  }
 
   @Override
   public void onLowMemory() {

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationFragmentActivity.kt
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationFragmentActivity.kt
@@ -8,7 +8,6 @@ import android.view.ViewGroup
 import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
-import androidx.fragment.app.Fragment
 import com.mapbox.android.core.location.LocationEngineCallback
 import com.mapbox.android.core.location.LocationEngineResult
 import com.mapbox.android.core.permissions.PermissionsListener
@@ -92,6 +91,7 @@ class LocationFragmentActivity : AppCompatActivity() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
       mapView = MapView(inflater.context)
+      mapView.attachLifeCycle(this)
       return mapView
     }
 
@@ -123,29 +123,9 @@ class LocationFragmentActivity : AppCompatActivity() {
       // noop
     }
 
-    override fun onStart() {
-      super.onStart()
-      mapView.onStart()
-    }
-
-    override fun onResume() {
-      super.onResume()
-      mapView.onResume()
-    }
-
-    override fun onPause() {
-      super.onPause()
-      mapView.onPause()
-    }
-
     override fun onSaveInstanceState(outState: Bundle) {
       super.onSaveInstanceState(outState)
       mapView.onSaveInstanceState(outState)
-    }
-
-    override fun onStop() {
-      super.onStop()
-      mapView.onStop()
     }
 
     override fun onLowMemory() {

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationMapChangeActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationMapChangeActivity.java
@@ -2,9 +2,13 @@ package com.mapbox.mapboxsdk.testapp.activity.location;
 
 import android.annotation.SuppressLint;
 import android.os.Bundle;
+
 import androidx.annotation.NonNull;
+
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
+
 import androidx.appcompat.app.AppCompatActivity;
+
 import android.widget.Toast;
 
 import com.mapbox.android.core.permissions.PermissionsListener;
@@ -32,6 +36,8 @@ public class LocationMapChangeActivity extends AppCompatActivity implements OnMa
     setContentView(R.layout.activity_location_layer_map_change);
 
     mapView = findViewById(R.id.mapView);
+    mapView.attachLifeCycle(this);
+
     FloatingActionButton stylesFab = findViewById(R.id.fabStyles);
 
     stylesFab.setOnClickListener(v -> {
@@ -98,40 +104,11 @@ public class LocationMapChangeActivity extends AppCompatActivity implements OnMa
       () -> Toast.makeText(this, "Location long clicked", Toast.LENGTH_SHORT).show());
   }
 
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
 
   @Override
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationModesActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationModesActivity.java
@@ -5,9 +5,11 @@ import android.content.res.Configuration;
 import android.graphics.RectF;
 import android.location.Location;
 import android.os.Bundle;
+
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.ListPopupWindow;
+
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -115,6 +117,7 @@ public class LocationModesActivity extends AppCompatActivity implements OnMapRea
         }
       });
       permissionsManager.requestLocationPermissions(this);
+      mapView.attachLifeCycle(this);
     }
   }
 
@@ -207,10 +210,10 @@ public class LocationModesActivity extends AppCompatActivity implements OnMapRea
     } else if (id == R.id.action_component_padding_animation_while_tracking) {
       Random paddingRandom = new Random();
       locationComponent.paddingWhileTracking(new double[] {
-          paddingRandom.nextDouble() * 500 * (paddingRandom.nextBoolean() ? -1 : 1),
-          paddingRandom.nextDouble() * 500 * (paddingRandom.nextBoolean() ? -1 : 1),
-          paddingRandom.nextDouble() * 500 * (paddingRandom.nextBoolean() ? -1 : 1),
-          paddingRandom.nextDouble() * 500 * (paddingRandom.nextBoolean() ? -1 : 1)
+        paddingRandom.nextDouble() * 500 * (paddingRandom.nextBoolean() ? -1 : 1),
+        paddingRandom.nextDouble() * 500 * (paddingRandom.nextBoolean() ? -1 : 1),
+        paddingRandom.nextDouble() * 500 * (paddingRandom.nextBoolean() ? -1 : 1),
+        paddingRandom.nextDouble() * 500 * (paddingRandom.nextBoolean() ? -1 : 1)
       }, 1000L, new MapboxMap.CancelableCallback() {
         @Override
         public void onCancel() {
@@ -302,30 +305,6 @@ public class LocationModesActivity extends AppCompatActivity implements OnMapRea
     locationComponent.applyStyle(options);
   }
 
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
-
   @SuppressLint("MissingPermission")
   @Override
   protected void onSaveInstanceState(Bundle outState) {
@@ -336,12 +315,6 @@ public class LocationModesActivity extends AppCompatActivity implements OnMapRea
     if (locationComponent != null) {
       outState.putParcelable(SAVED_STATE_LOCATION, locationComponent.getLastKnownLocation());
     }
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/ManualLocationUpdatesActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/ManualLocationUpdatesActivity.java
@@ -74,6 +74,7 @@ public class ManualLocationUpdatesActivity extends AppCompatActivity implements 
 
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
+    mapView.attachLifeCycle(this);
 
     if (PermissionsManager.areLocationPermissionsGranted(this)) {
       mapView.getMapAsync(this);
@@ -127,39 +128,9 @@ public class ManualLocationUpdatesActivity extends AppCompatActivity implements 
   }
 
   @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
-
-  @Override
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/BottomSheetActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/BottomSheetActivity.java
@@ -2,19 +2,24 @@ package com.mapbox.mapboxsdk.testapp.activity.maplayout;
 
 import android.content.Context;
 import android.os.Bundle;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
+
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
+
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Toast;
+
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapView;
@@ -162,29 +167,6 @@ public class BottomSheetActivity extends AppCompatActivity {
       );
     }
 
-    @Override
-    public void onStart() {
-      super.onStart();
-      map.onStart();
-    }
-
-    @Override
-    public void onResume() {
-      super.onResume();
-      map.onResume();
-    }
-
-    @Override
-    public void onPause() {
-      super.onPause();
-      map.onPause();
-    }
-
-    @Override
-    public void onStop() {
-      super.onStop();
-      map.onStop();
-    }
 
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {
@@ -198,11 +180,6 @@ public class BottomSheetActivity extends AppCompatActivity {
       map.onLowMemory();
     }
 
-    @Override
-    public void onDestroyView() {
-      super.onDestroyView();
-      map.onDestroy();
-    }
   }
 
   public static class BottomSheetFragment extends Fragment implements OnMapReadyCallback {
@@ -221,7 +198,9 @@ public class BottomSheetActivity extends AppCompatActivity {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
       super.onCreateView(inflater, container, savedInstanceState);
       Context context = inflater.getContext();
-      return map = new MapView(context, MapFragmentUtils.resolveArgs(context, getArguments()));
+      map = new MapView(context, MapFragmentUtils.resolveArgs(context, getArguments()));
+      map.attachLifeCycle(this);
+      return map;
     }
 
     @Override
@@ -235,30 +214,6 @@ public class BottomSheetActivity extends AppCompatActivity {
     public void onMapReady(@NonNull MapboxMap mapboxMap) {
       mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(new LatLng(37.760545, -122.436055), 15));
       mapboxMap.setStyle(Style.LIGHT);
-    }
-
-    @Override
-    public void onStart() {
-      super.onStart();
-      map.onStart();
-    }
-
-    @Override
-    public void onResume() {
-      super.onResume();
-      map.onResume();
-    }
-
-    @Override
-    public void onPause() {
-      super.onPause();
-      map.onPause();
-    }
-
-    @Override
-    public void onStop() {
-      super.onStop();
-      map.onStop();
     }
 
     @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DebugModeActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DebugModeActivity.java
@@ -2,12 +2,16 @@ package com.mapbox.mapboxsdk.testapp.activity.maplayout;
 
 import android.content.Context;
 import android.os.Bundle;
+
 import androidx.annotation.NonNull;
+
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
+
 import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.ActionBarDrawerToggle;
 import androidx.appcompat.app.AppCompatActivity;
+
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -109,6 +113,7 @@ public class DebugModeActivity extends AppCompatActivity implements OnMapReadyCa
     mapView.onCreate(savedInstanceState);
     mapView.getMapAsync(this);
     mapView.addOnDidFinishLoadingStyleListener(() -> Timber.d("Style loaded"));
+    mapView.attachLifeCycle(this);
   }
 
   protected MapboxMapOptions setupMapboxMapOptions() {
@@ -219,30 +224,6 @@ public class DebugModeActivity extends AppCompatActivity implements OnMapReadyCa
   }
 
   @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
-
-  @Override
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
@@ -255,7 +236,6 @@ public class DebugModeActivity extends AppCompatActivity implements OnMapReadyCa
       mapboxMap.unsubscribe(observer);
       mapboxMap.removeOnCameraMoveListener(cameraMoveListener);
     }
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DoubleMapActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DoubleMapActivity.java
@@ -2,14 +2,17 @@ package com.mapbox.mapboxsdk.testapp.activity.maplayout;
 
 import android.content.Intent;
 import android.os.Bundle;
+
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentTransaction;
 import androidx.appcompat.app.AppCompatActivity;
+
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Toast;
+
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
@@ -75,12 +78,14 @@ public class DoubleMapActivity extends AppCompatActivity {
       // MapView large
       mapView = new MapView(view.getContext(), MapFragmentUtils.resolveArgs(view.getContext(), getArguments()));
       mapView.onCreate(savedInstanceState);
+      mapView.attachLifeCycle(this);
       mapView.getMapAsync(mapboxMap -> mapboxMap.setStyle(Style.MAPBOX_STREETS));
       ((ViewGroup) view.findViewById(R.id.container)).addView(mapView, 0);
 
       // MapView mini
       mapViewMini = view.findViewById(R.id.mini_map);
       mapViewMini.onCreate(savedInstanceState);
+      mapViewMini.attachLifeCycle(this);
       mapViewMini.getMapAsync(mapboxMap -> {
         mapboxMap.moveCamera(CameraUpdateFactory.newCameraPosition(
           new CameraPosition.Builder().target(MACHU_PICCHU)
@@ -106,40 +111,6 @@ public class DoubleMapActivity extends AppCompatActivity {
       });
     }
 
-    @Override
-    public void onResume() {
-      super.onResume();
-      mapView.onResume();
-      mapViewMini.onResume();
-    }
-
-    @Override
-    public void onStart() {
-      super.onStart();
-      mapView.onStart();
-      mapViewMini.onStart();
-    }
-
-    @Override
-    public void onPause() {
-      super.onPause();
-      mapView.onPause();
-      mapViewMini.onPause();
-    }
-
-    @Override
-    public void onStop() {
-      super.onStop();
-      mapView.onStop();
-      mapViewMini.onStop();
-    }
-
-    @Override
-    public void onDestroyView() {
-      super.onDestroyView();
-      mapView.onDestroy();
-      mapViewMini.onDestroy();
-    }
 
     @Override
     public void onLowMemory() {

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/LatLngBoundsForCameraActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/LatLngBoundsForCameraActivity.java
@@ -2,14 +2,17 @@ package com.mapbox.mapboxsdk.testapp.activity.maplayout;
 
 import android.graphics.Color;
 import android.os.Bundle;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+
 import android.view.Gravity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.FrameLayout;
+
 import com.mapbox.mapboxsdk.annotations.PolygonOptions;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.geometry.LatLngBounds;
@@ -50,6 +53,7 @@ public class LatLngBoundsForCameraActivity extends AppCompatActivity implements 
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
     mapView.getMapAsync(this);
+    mapView.attachLifeCycle(this);
   }
 
   @Override
@@ -110,40 +114,11 @@ public class LatLngBoundsForCameraActivity extends AppCompatActivity implements 
     mapView.addView(crosshair);
   }
 
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
 
   @Override
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/LocalGlyphActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/LocalGlyphActivity.java
@@ -1,7 +1,9 @@
 package com.mapbox.mapboxsdk.testapp.activity.maplayout;
 
 import android.os.Bundle;
+
 import androidx.appcompat.app.AppCompatActivity;
+
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
@@ -23,6 +25,7 @@ public class LocalGlyphActivity extends AppCompatActivity {
 
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
+    mapView.attachLifeCycle(this);
     mapView.getMapAsync(mapboxMap -> {
       mapboxMap.setStyle(Style.MAPBOX_STREETS);
       // Set initial position to Suzhou
@@ -37,40 +40,11 @@ public class LocalGlyphActivity extends AppCompatActivity {
   }
 
   @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
-
-  @Override
   public void onLowMemory() {
     super.onLowMemory();
     mapView.onLowMemory();
   }
 
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
-  }
 
   @Override
   protected void onSaveInstanceState(Bundle outState) {

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/MapChangeActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/MapChangeActivity.java
@@ -1,6 +1,7 @@
 package com.mapbox.mapboxsdk.testapp.activity.maplayout;
 
 import android.os.Bundle;
+
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
@@ -43,42 +44,13 @@ public class MapChangeActivity extends AppCompatActivity {
       mapboxMap.animateCamera(CameraUpdateFactory.newLatLngZoom(
         new LatLng(55.754020, 37.620948), 12), 9000);
     });
-  }
-
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
+    mapView.attachLifeCycle(this);
   }
 
   @Override
   public void onLowMemory() {
     super.onLowMemory();
     mapView.onLowMemory();
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/MapInDialogActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/MapInDialogActivity.java
@@ -58,30 +58,7 @@ public class MapInDialogActivity extends AppCompatActivity {
       mapView = view.findViewById(R.id.mapView);
       mapView.onCreate(savedInstanceState);
       mapView.getMapAsync(mapboxMap -> mapboxMap.setStyle(Style.OUTDOORS));
-    }
-
-    @Override
-    public void onStart() {
-      super.onStart();
-      mapView.onStart();
-    }
-
-    @Override
-    public void onResume() {
-      super.onResume();
-      mapView.onResume();
-    }
-
-    @Override
-    public void onPause() {
-      super.onPause();
-      mapView.onPause();
-    }
-
-    @Override
-    public void onStop() {
-      super.onStop();
-      mapView.onStop();
+      mapView.attachLifeCycle(this);
     }
 
     @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/MapPaddingActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/MapPaddingActivity.java
@@ -1,7 +1,9 @@
 package com.mapbox.mapboxsdk.testapp.activity.maplayout;
 
 import android.os.Bundle;
+
 import androidx.appcompat.app.AppCompatActivity;
+
 import android.view.Menu;
 import android.view.MenuItem;
 
@@ -31,7 +33,7 @@ public class MapPaddingActivity extends AppCompatActivity {
     mapView = findViewById(R.id.mapView);
     mapView.setTag(true);
     mapView.onCreate(savedInstanceState);
-
+    mapView.attachLifeCycle(this);
     mapView.getMapAsync(mapboxMap -> {
       MapPaddingActivity.this.mapboxMap = mapboxMap;
       mapboxMap.setStyle(Style.MAPBOX_STREETS);
@@ -52,39 +54,9 @@ public class MapPaddingActivity extends AppCompatActivity {
   }
 
   @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
-
-  @Override
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/SimpleMapActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/SimpleMapActivity.java
@@ -24,42 +24,14 @@ public class SimpleMapActivity extends AppCompatActivity {
     mapView.getMapAsync(mapboxMap -> mapboxMap.setStyle(
       new Style.Builder().fromUri(Style.MAPBOX_STREETS)
     ));
+    mapView.attachLifeCycle(this);
   }
 
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
 
   @Override
   public void onLowMemory() {
     super.onLowMemory();
     mapView.onLowMemory();
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/VisibilityChangeActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/VisibilityChangeActivity.java
@@ -35,19 +35,14 @@ public class VisibilityChangeActivity extends AppCompatActivity {
       mapboxMap.animateCamera(CameraUpdateFactory.newLatLngZoom(
         new LatLng(55.754020, 37.620948), 12), 9000);
     });
+
+    mapView.attachLifeCycle(this);
   }
 
   @Override
   protected void onStart() {
     super.onStart();
-    mapView.onStart();
     handler.post(runnable = new VisibilityRunner(mapView, findViewById(R.id.viewParent), handler));
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
   }
 
   private static class VisibilityRunner implements Runnable {
@@ -109,19 +104,12 @@ public class VisibilityChangeActivity extends AppCompatActivity {
   }
 
   @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
   protected void onStop() {
     super.onStop();
     if (runnable != null) {
       handler.removeCallbacks(runnable);
       runnable = null;
     }
-    mapView.onStop();
   }
 
   @Override
@@ -130,11 +118,6 @@ public class VisibilityChangeActivity extends AppCompatActivity {
     mapView.onLowMemory();
   }
 
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
-  }
 
   @Override
   protected void onSaveInstanceState(Bundle outState) {

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/offline/OfflineActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/offline/OfflineActivity.java
@@ -1,7 +1,9 @@
 package com.mapbox.mapboxsdk.testapp.activity.offline;
 
 import android.os.Bundle;
+
 import androidx.appcompat.app.AppCompatActivity;
+
 import android.text.TextUtils;
 import android.view.View;
 import android.widget.Button;
@@ -77,6 +79,7 @@ public class OfflineActivity extends AppCompatActivity
     // Set up map
     mapView = (MapView) findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
+    mapView.attachLifeCycle(this);
     mapView.getMapAsync(mapboxMap -> {
       Timber.d("Map is ready");
       OfflineActivity.this.mapboxMap = mapboxMap;
@@ -105,40 +108,11 @@ public class OfflineActivity extends AppCompatActivity
     offlineManager = OfflineManager.getInstance(this);
   }
 
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
 
   @Override
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
   @Override
@@ -189,7 +163,7 @@ public class OfflineActivity extends AppCompatActivity
 
       @Override
       public void onError(String error) {
-        Timber.e("Error: %s" , error);
+        Timber.e("Error: %s", error);
       }
     });
   }
@@ -223,7 +197,7 @@ public class OfflineActivity extends AppCompatActivity
     offlineManager.createOfflineRegion(definition, metadata, new OfflineManager.CreateOfflineRegionCallback() {
       @Override
       public void onCreate(OfflineRegion offlineRegion) {
-        Timber.d("Offline region created: %s" , regionName);
+        Timber.d("Offline region created: %s", regionName);
         OfflineActivity.this.offlineRegion = offlineRegion;
         launchDownload();
       }

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/storage/UrlTransformActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/storage/UrlTransformActivity.java
@@ -49,31 +49,9 @@ public class UrlTransformActivity extends AppCompatActivity {
       Timber.i("Map loaded");
       map.setStyle(Style.MAPBOX_STREETS);
     });
+    mapView.attachLifeCycle(this);
   }
 
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
 
   @Override
   protected void onSaveInstanceState(Bundle outState) {
@@ -88,7 +66,6 @@ public class UrlTransformActivity extends AppCompatActivity {
     // Example of how to reset the transform callback
     FileSource.getInstance(UrlTransformActivity.this).setResourceTransform(null);
 
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/AnimatedImageSourceActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/AnimatedImageSourceActivity.java
@@ -6,6 +6,7 @@ import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.os.Handler;
+
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -44,6 +45,8 @@ public class AnimatedImageSourceActivity extends AppCompatActivity implements On
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
     mapView.getMapAsync(this);
+    mapView.attachLifeCycle(this);
+
   }
 
   @Override
@@ -66,35 +69,11 @@ public class AnimatedImageSourceActivity extends AppCompatActivity implements On
     );
   }
 
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  public void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  public void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
 
   @Override
   protected void onStop() {
     super.onStop();
-    mapView.onStop();
     handler.removeCallbacks(runnable);
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/BuildingFillExtrusionActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/BuildingFillExtrusionActivity.java
@@ -2,7 +2,9 @@ package com.mapbox.mapboxsdk.testapp.activity.style;
 
 import android.graphics.Color;
 import android.os.Bundle;
+
 import androidx.appcompat.app.AppCompatActivity;
+
 import android.view.Menu;
 import android.view.MenuItem;
 
@@ -45,6 +47,7 @@ public class BuildingFillExtrusionActivity extends AppCompatActivity {
     setContentView(R.layout.activity_building_layer);
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
+    mapView.attachLifeCycle(this);
     mapView.getMapAsync(map -> {
       mapboxMap = map;
       mapboxMap.setStyle(Style.MAPBOX_STREETS, style -> {
@@ -108,30 +111,6 @@ public class BuildingFillExtrusionActivity extends AppCompatActivity {
   }
 
   @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
-
-  @Override
   public void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
@@ -143,9 +122,4 @@ public class BuildingFillExtrusionActivity extends AppCompatActivity {
     mapView.onLowMemory();
   }
 
-  @Override
-  public void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
-  }
 }

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/CircleLayerActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/CircleLayerActivity.java
@@ -2,11 +2,15 @@ package com.mapbox.mapboxsdk.testapp.activity.style;
 
 import android.graphics.Color;
 import android.os.Bundle;
+
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
+
 import androidx.core.content.ContextCompat;
 import androidx.core.content.res.ResourcesCompat;
 import androidx.appcompat.app.AppCompatActivity;
+
 import android.view.View;
+
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.Style;
@@ -16,6 +20,7 @@ import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 import com.mapbox.mapboxsdk.testapp.R;
+
 import timber.log.Timber;
 
 import java.net.URI;
@@ -49,7 +54,8 @@ public class CircleLayerActivity extends AppCompatActivity implements View.OnCli
 
   public static final String SOURCE_ID = "bus_stop";
   public static final String SOURCE_ID_CLUSTER = "bus_stop_cluster";
-  public static final String URL_BUS_ROUTES = "https://raw.githubusercontent.com/cheeaun/busrouter-sg/master/data/2/bus-stops.geojson";
+  public static final String URL_BUS_ROUTES =
+    "https://raw.githubusercontent.com/cheeaun/busrouter-sg/master/data/2/bus-stops.geojson";
   public static final String LAYER_ID = "stops_layer";
   private MapView mapView;
   private MapboxMap mapboxMap;
@@ -70,6 +76,7 @@ public class CircleLayerActivity extends AppCompatActivity implements View.OnCli
 
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
+    mapView.attachLifeCycle(this);
     mapView.getMapAsync(map -> {
       mapboxMap = map;
       mapboxMap.setStyle(Style.SATELLITE_STREETS);
@@ -230,30 +237,6 @@ public class CircleLayerActivity extends AppCompatActivity implements View.OnCli
   }
 
   @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
-
-  @Override
   public void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
@@ -263,12 +246,6 @@ public class CircleLayerActivity extends AppCompatActivity implements View.OnCli
   public void onLowMemory() {
     super.onLowMemory();
     mapView.onLowMemory();
-  }
-
-  @Override
-  public void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
   private static class Data {

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/CustomSpriteActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/CustomSpriteActivity.java
@@ -2,9 +2,12 @@ package com.mapbox.mapboxsdk.testapp.activity.style;
 
 import android.graphics.BitmapFactory;
 import android.os.Bundle;
+
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
+
 import androidx.core.content.ContextCompat;
 import androidx.appcompat.app.AppCompatActivity;
+
 import android.view.View;
 
 import com.mapbox.geojson.Feature;
@@ -46,6 +49,7 @@ public class CustomSpriteActivity extends AppCompatActivity {
 
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
+    mapView.attachLifeCycle(this);
     mapView.getMapAsync(map -> {
       mapboxMap = map;
 
@@ -101,30 +105,6 @@ public class CustomSpriteActivity extends AppCompatActivity {
   }
 
   @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
-
-  @Override
   public void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
@@ -136,9 +116,4 @@ public class CustomSpriteActivity extends AppCompatActivity {
     mapView.onLowMemory();
   }
 
-  @Override
-  public void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
-  }
 }

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/DataDrivenStyleActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/DataDrivenStyleActivity.java
@@ -2,7 +2,9 @@ package com.mapbox.mapboxsdk.testapp.activity.style;
 
 import android.graphics.Color;
 import android.os.Bundle;
+
 import androidx.appcompat.app.AppCompatActivity;
+
 import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.TextView;
@@ -59,7 +61,7 @@ public class DataDrivenStyleActivity extends AppCompatActivity {
     // Initialize map as normal
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
-
+    mapView.attachLifeCycle(this);
     mapView.getMapAsync(map -> {
       // Store for later
       mapboxMap = map;
@@ -89,30 +91,6 @@ public class DataDrivenStyleActivity extends AppCompatActivity {
   }
 
   @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
-
-  @Override
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
@@ -124,7 +102,6 @@ public class DataDrivenStyleActivity extends AppCompatActivity {
     if (mapboxMap != null && idleListener != null) {
       mapboxMap.removeOnCameraIdleListener(idleListener);
     }
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/DraggableMarkerActivity.kt
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/DraggableMarkerActivity.kt
@@ -65,6 +65,7 @@ class DraggableMarkerActivity : AppCompatActivity() {
 
     mapView = findViewById(R.id.mapView)
     mapView.onCreate(savedInstanceState)
+    mapView.attachLifeCycle(this)
     mapView.getMapAsync { mapboxMap ->
       this.mapboxMap = mapboxMap
 
@@ -288,34 +289,9 @@ class DraggableMarkerActivity : AppCompatActivity() {
     }
   }
 
-  override fun onStart() {
-    super.onStart()
-    mapView.onStart()
-  }
-
-  override fun onResume() {
-    super.onResume()
-    mapView.onResume()
-  }
-
-  override fun onPause() {
-    super.onPause()
-    mapView.onPause()
-  }
-
-  override fun onStop() {
-    super.onStop()
-    mapView.onStop()
-  }
-
   override fun onLowMemory() {
     super.onLowMemory()
     mapView.onLowMemory()
-  }
-
-  override fun onDestroy() {
-    super.onDestroy()
-    mapView.onDestroy()
   }
 
   override fun onSaveInstanceState(outState: Bundle) {

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/FillExtrusionActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/FillExtrusionActivity.java
@@ -2,6 +2,7 @@ package com.mapbox.mapboxsdk.testapp.activity.style;
 
 import android.graphics.Color;
 import android.os.Bundle;
+
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.mapbox.geojson.Point;
@@ -37,6 +38,7 @@ public class FillExtrusionActivity extends AppCompatActivity {
 
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
+    mapView.attachLifeCycle(this);
     mapView.getMapAsync(mapboxMap -> {
       mapboxMap.setStyle(Style.MAPBOX_STREETS, style -> {
         List<List<Point>> lngLats = Collections.singletonList(
@@ -78,30 +80,6 @@ public class FillExtrusionActivity extends AppCompatActivity {
 
 
   @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
-
-  @Override
   public void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
@@ -111,12 +89,6 @@ public class FillExtrusionActivity extends AppCompatActivity {
   public void onLowMemory() {
     super.onLowMemory();
     mapView.onLowMemory();
-  }
-
-  @Override
-  public void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
 }

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/FillExtrusionStyleTestActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/FillExtrusionStyleTestActivity.java
@@ -1,7 +1,9 @@
 package com.mapbox.mapboxsdk.testapp.activity.style;
 
 import android.os.Bundle;
+
 import androidx.appcompat.app.AppCompatActivity;
+
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.Style;
@@ -23,6 +25,7 @@ public class FillExtrusionStyleTestActivity extends AppCompatActivity {
     // Initialize map as normal
     mapView = (MapView) findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
+    mapView.attachLifeCycle(this);
     mapView.getMapAsync(mapboxMap ->
       mapboxMap.setStyle(new Style.Builder().fromUri(Style.MAPBOX_STREETS),
         style -> FillExtrusionStyleTestActivity.this.mapboxMap = mapboxMap
@@ -35,39 +38,9 @@ public class FillExtrusionStyleTestActivity extends AppCompatActivity {
   }
 
   @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
-
-  @Override
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/GeoJsonClusteringActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/GeoJsonClusteringActivity.java
@@ -78,7 +78,7 @@ public class GeoJsonClusteringActivity extends AppCompatActivity {
     mapView = findViewById(R.id.mapView);
     // noinspection ConstantConditions
     mapView.onCreate(savedInstanceState);
-
+    mapView.attachLifeCycle(this);
     mapView.getMapAsync(map -> {
       mapboxMap = map;
       mapboxMap.animateCamera(CameraUpdateFactory.newLatLngZoom(new LatLng(37.7749, 122.4194), 0));
@@ -199,40 +199,11 @@ public class GeoJsonClusteringActivity extends AppCompatActivity {
       );
   }
 
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
 
   @Override
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/GradientLineActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/GradientLineActivity.java
@@ -2,8 +2,10 @@ package com.mapbox.mapboxsdk.testapp.activity.style;
 
 import android.graphics.Color;
 import android.os.Bundle;
+
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
+
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
@@ -13,6 +15,7 @@ import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 import com.mapbox.mapboxsdk.testapp.R;
 import com.mapbox.mapboxsdk.testapp.utils.ResourceUtils;
+
 import timber.log.Timber;
 
 import java.io.IOException;
@@ -46,6 +49,7 @@ public class GradientLineActivity extends AppCompatActivity implements OnMapRead
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
     mapView.getMapAsync(this);
+    mapView.attachLifeCycle(this);
   }
 
   @Override
@@ -74,30 +78,6 @@ public class GradientLineActivity extends AppCompatActivity implements OnMapRead
   }
 
   @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
-
-  @Override
   public void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
@@ -109,9 +89,4 @@ public class GradientLineActivity extends AppCompatActivity implements OnMapRead
     mapView.onLowMemory();
   }
 
-  @Override
-  public void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
-  }
 }

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/GridSourceActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/GridSourceActivity.java
@@ -2,6 +2,7 @@ package com.mapbox.mapboxsdk.testapp.activity.style;
 
 import android.graphics.Color;
 import android.os.Bundle;
+
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -98,6 +99,7 @@ public class GridSourceActivity extends AppCompatActivity implements OnMapReadyC
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
     mapView.getMapAsync(this);
+    mapView.attachLifeCycle(this);
   }
 
   @Override
@@ -113,36 +115,6 @@ public class GridSourceActivity extends AppCompatActivity implements OnMapReadyC
       .withLayer(layer)
       .withSource(source)
     );
-  }
-
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  public void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  public void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/HeatmapLayerActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/HeatmapLayerActivity.java
@@ -1,7 +1,9 @@
 package com.mapbox.mapboxsdk.testapp.activity.style;
 
 import android.os.Bundle;
+
 import androidx.appcompat.app.AppCompatActivity;
+
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.Style;
@@ -9,6 +11,7 @@ import com.mapbox.mapboxsdk.style.layers.CircleLayer;
 import com.mapbox.mapboxsdk.style.layers.HeatmapLayer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 import com.mapbox.mapboxsdk.testapp.R;
+
 import timber.log.Timber;
 
 import java.net.URI;
@@ -54,6 +57,7 @@ public class HeatmapLayerActivity extends AppCompatActivity {
     setContentView(R.layout.activity_heatmaplayer);
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
+    mapView.attachLifeCycle(this);
     mapView.getMapAsync(map -> {
       mapboxMap = map;
 
@@ -185,30 +189,6 @@ public class HeatmapLayerActivity extends AppCompatActivity {
   }
 
   @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
-
-  @Override
   public void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
@@ -218,11 +198,5 @@ public class HeatmapLayerActivity extends AppCompatActivity {
   public void onLowMemory() {
     super.onLowMemory();
     mapView.onLowMemory();
-  }
-
-  @Override
-  public void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 }

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/HillshadeLayerActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/HillshadeLayerActivity.java
@@ -1,6 +1,7 @@
 package com.mapbox.mapboxsdk.testapp.activity.style;
 
 import android.os.Bundle;
+
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.mapbox.mapboxsdk.maps.MapView;
@@ -30,6 +31,7 @@ public class HillshadeLayerActivity extends AppCompatActivity {
 
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
+    mapView.attachLifeCycle(this);
     mapView.getMapAsync(map -> {
       mapboxMap = map;
 
@@ -43,29 +45,6 @@ public class HillshadeLayerActivity extends AppCompatActivity {
     });
   }
 
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
 
   @Override
   public void onSaveInstanceState(Bundle outState) {
@@ -79,9 +58,4 @@ public class HillshadeLayerActivity extends AppCompatActivity {
     mapView.onLowMemory();
   }
 
-  @Override
-  public void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
-  }
 }

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/ImageInLabelActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/ImageInLabelActivity.java
@@ -44,6 +44,7 @@ public class ImageInLabelActivity extends AppCompatActivity implements OnMapRead
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
     mapView.getMapAsync(this);
+    mapView.attachLifeCycle(this);
   }
 
   @Override
@@ -87,30 +88,6 @@ public class ImageInLabelActivity extends AppCompatActivity implements OnMapRead
   }
 
   @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
-
-  @Override
   public void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
@@ -120,12 +97,6 @@ public class ImageInLabelActivity extends AppCompatActivity implements OnMapRead
   public void onLowMemory() {
     super.onLowMemory();
     mapView.onLowMemory();
-  }
-
-  @Override
-  public void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
 }

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/RealTimeGeoJsonActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/RealTimeGeoJsonActivity.java
@@ -44,6 +44,7 @@ public class RealTimeGeoJsonActivity extends AppCompatActivity implements OnMapR
     mapView = (MapView) findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
     mapView.getMapAsync(this);
+    mapView.attachLifeCycle(this);
   }
 
   @Override
@@ -73,36 +74,13 @@ public class RealTimeGeoJsonActivity extends AppCompatActivity implements OnMapR
     });
   }
 
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  public void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  public void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
 
   @Override
   protected void onStop() {
     super.onStop();
-    mapView.onStop();
     handler.removeCallbacks(runnable);
   }
 
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
-  }
 
   @Override
   protected void onSaveInstanceState(Bundle outState) {

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/RuntimeStyleActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/RuntimeStyleActivity.java
@@ -131,6 +131,8 @@ public class RuntimeStyleActivity extends AppCompatActivity {
         }
       );
     });
+
+    mapView.attachLifeCycle(this);
   }
 
   @Override
@@ -139,40 +141,12 @@ public class RuntimeStyleActivity extends AppCompatActivity {
     return true;
   }
 
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
 
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
 
   @Override
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/RuntimeStyleTimingTestActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/RuntimeStyleTimingTestActivity.java
@@ -49,46 +49,19 @@ public class RuntimeStyleTimingTestActivity extends AppCompatActivity {
         .withSource(museums)
         .withLayer(museumsLayer));
     });
+
+    mapView.attachLifeCycle(this);
   }
 
   public MapboxMap getMapboxMap() {
     return mapboxMap;
   }
 
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
 
   @Override
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/StretchableImageActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/StretchableImageActivity.java
@@ -56,6 +56,7 @@ public class StretchableImageActivity extends AppCompatActivity implements OnMap
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
     mapView.getMapAsync(this);
+    mapView.attachLifeCycle(this);
   }
 
   @Override
@@ -153,29 +154,6 @@ public class StretchableImageActivity extends AppCompatActivity implements OnMap
   }
 
 
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
 
   @Override
   public void onSaveInstanceState(Bundle outState) {
@@ -187,12 +165,6 @@ public class StretchableImageActivity extends AppCompatActivity implements OnMap
   public void onLowMemory() {
     super.onLowMemory();
     mapView.onLowMemory();
-  }
-
-  @Override
-  public void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
 }

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/StyleFileActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/StyleFileActivity.java
@@ -47,6 +47,7 @@ public class StyleFileActivity extends AppCompatActivity {
         fabStyleJson.setOnClickListener(view -> new LoadStyleFileTask(view.getContext(), mapboxMap).execute());
       });
     });
+    mapView.attachLifeCycle(this);
   }
 
   /**
@@ -133,29 +134,7 @@ public class StyleFileActivity extends AppCompatActivity {
     }
   }
 
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
 
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
 
   @Override
   public void onSaveInstanceState(Bundle outState) {
@@ -169,9 +148,4 @@ public class StyleFileActivity extends AppCompatActivity {
     mapView.onLowMemory();
   }
 
-  @Override
-  public void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
-  }
 }

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/SymbolGeneratorActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/SymbolGeneratorActivity.java
@@ -88,6 +88,7 @@ public class SymbolGeneratorActivity extends AppCompatActivity implements OnMapR
     mapView = (MapView) findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
     mapView.getMapAsync(this);
+    mapView.attachLifeCycle(this);
   }
 
   @Override
@@ -143,29 +144,7 @@ public class SymbolGeneratorActivity extends AppCompatActivity implements OnMapR
     return super.onOptionsItemSelected(item);
   }
 
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
 
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
 
   @Override
   public void onSaveInstanceState(Bundle outState) {
@@ -179,11 +158,6 @@ public class SymbolGeneratorActivity extends AppCompatActivity implements OnMapR
     mapView.onLowMemory();
   }
 
-  @Override
-  public void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
-  }
 
   /**
    * Utility class to generate Bitmaps for Symbol.

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/SymbolLayerActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/SymbolLayerActivity.java
@@ -146,6 +146,7 @@ public class SymbolLayerActivity extends AppCompatActivity implements MapboxMap.
         style.addImage(id, Objects.requireNonNull(androidIcon));
       }
     });
+    mapView.attachLifeCycle(this);
   }
 
   @Override
@@ -305,29 +306,9 @@ public class SymbolLayerActivity extends AppCompatActivity implements MapboxMap.
     return object;
   }
 
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
 
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
 
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
 
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
 
   @Override
   public void onSaveInstanceState(Bundle outState) {
@@ -347,7 +328,6 @@ public class SymbolLayerActivity extends AppCompatActivity implements MapboxMap.
     if (mapboxMap != null) {
       mapboxMap.removeOnMapClickListener(this);
     }
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/ZoomFunctionSymbolLayerActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/ZoomFunctionSymbolLayerActivity.java
@@ -87,6 +87,7 @@ public class ZoomFunctionSymbolLayerActivity extends AppCompatActivity {
         map.addOnMapClickListener(mapClickListener);
       });
     });
+    mapView.attachLifeCycle(this);
   }
 
   private void updateSource(Style style) {
@@ -156,30 +157,6 @@ public class ZoomFunctionSymbolLayerActivity extends AppCompatActivity {
   }
 
   @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
-
-  @Override
   public void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
@@ -191,9 +168,4 @@ public class ZoomFunctionSymbolLayerActivity extends AppCompatActivity {
     mapView.onLowMemory();
   }
 
-  @Override
-  public void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
-  }
 }

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/telemetry/PerformanceMeasurementActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/telemetry/PerformanceMeasurementActivity.java
@@ -49,44 +49,14 @@ public class PerformanceMeasurementActivity extends AppCompatActivity {
 
     mapView.getMapAsync(mapboxMap -> mapboxMap.setStyle(
       new Style.Builder().fromUri(Style.MAPBOX_STREETS)));
-  }
 
-
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
+    mapView.attachLifeCycle(this);
   }
 
   @Override
   public void onLowMemory() {
     super.onLowMemory();
     mapView.onLowMemory();
-  }
-
-  @Override
-  protected void onDestroy() {
-    HttpRequestUtil.setOkHttpClient(null);
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/textureview/TextureViewAnimationActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/textureview/TextureViewAnimationActivity.java
@@ -72,6 +72,8 @@ public class TextureViewAnimationActivity extends AppCompatActivity {
       // Start an animation on the map as well
       flyTo(mapboxMap, 0, 14);
     });
+
+    mapView.attachLifeCycle(this);
   }
 
   private void flyTo(final MapboxMap mapboxMap, final int place, final double zoom) {
@@ -100,28 +102,11 @@ public class TextureViewAnimationActivity extends AppCompatActivity {
     mapboxMap.setOnFpsChangedListener(fps -> fpsView.setText(String.format(Locale.US, "FPS: %4.2f", fps)));
   }
 
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
 
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
 
   @Override
   protected void onStop() {
     super.onStop();
-    mapView.onStop();
     if (handler != null && delayed != null) {
       handler.removeCallbacks(delayed);
     }
@@ -133,11 +118,6 @@ public class TextureViewAnimationActivity extends AppCompatActivity {
     mapView.onSaveInstanceState(outState);
   }
 
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
-  }
 
   @Override
   public void onLowMemory() {

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/textureview/TextureViewResizeActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/textureview/TextureViewResizeActivity.java
@@ -40,6 +40,7 @@ public class TextureViewResizeActivity extends AppCompatActivity {
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
     mapView.getMapAsync(this::setupMap);
+    mapView.attachLifeCycle(this);
   }
 
   private void setupMap(MapboxMap mapboxMap) {
@@ -58,29 +59,7 @@ public class TextureViewResizeActivity extends AppCompatActivity {
     });
   }
 
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
 
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
 
   @Override
   protected void onSaveInstanceState(Bundle outState) {
@@ -88,11 +67,6 @@ public class TextureViewResizeActivity extends AppCompatActivity {
     mapView.onSaveInstanceState(outState);
   }
 
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
-  }
 
   @Override
   public void onLowMemory() {

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/textureview/TextureViewTransparentBackgroundActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/textureview/TextureViewTransparentBackgroundActivity.java
@@ -52,6 +52,7 @@ public class TextureViewTransparentBackgroundActivity extends AppCompatActivity 
     mapView.onCreate(savedInstanceState);
     mapView.getMapAsync(this::initMap);
     ((ViewGroup) findViewById(R.id.coordinator_layout)).addView(mapView);
+    mapView.attachLifeCycle(this);
   }
 
   private void initMap(MapboxMap mapboxMap) {
@@ -64,40 +65,11 @@ public class TextureViewTransparentBackgroundActivity extends AppCompatActivity 
     }
   }
 
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mapView.onStart();
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    mapView.onResume();
-  }
-
-  @Override
-  protected void onPause() {
-    super.onPause();
-    mapView.onPause();
-  }
-
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mapView.onStop();
-  }
 
   @Override
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
-  }
-
-  @Override
-  protected void onDestroy() {
-    super.onDestroy();
-    mapView.onDestroy();
   }
 
   @Override

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/turf/WithinExpressionActivity.kt
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/turf/WithinExpressionActivity.kt
@@ -59,6 +59,8 @@ class WithinExpressionActivity : AppCompatActivity() {
       // Load mapbox streets and add lines and circles
       setupStyle()
     }
+
+    mapView.attachLifeCycle(this)
   }
 
   private fun setupStyle() {
@@ -157,25 +159,10 @@ class WithinExpressionActivity : AppCompatActivity() {
     (style.getLayer("road-number-shield") as SymbolLayer).setProperties(visibility(NONE))
   }
 
-  override fun onStart() {
-    super.onStart()
-    mapView.onStart()
-  }
 
-  override fun onResume() {
-    super.onResume()
-    mapView.onResume()
-  }
 
-  override fun onPause() {
-    super.onPause()
-    mapView.onPause()
-  }
 
-  override fun onStop() {
-    super.onStop()
-    mapView.onStop()
-  }
+
 
   override fun onLowMemory() {
     super.onLowMemory()
@@ -185,7 +172,6 @@ class WithinExpressionActivity : AppCompatActivity() {
   override fun onDestroy() {
     super.onDestroy()
     handler.removeCallbacks(runnable)
-    mapView.onDestroy()
   }
 
   override fun onSaveInstanceState(outState: Bundle) {


### PR DESCRIPTION


`<changelog>
**Make MapView a LifeCycleObserver of Android's LifeCycle events**

> MapView is dependant on Android's LifeCycle events. This commit instead of requiring the developer to call MapView's corresponding Life cycle events method, we let the LIfeCycleOwner which cna be any of Activity,Fragment or any class that extends LifeCycle Owner take care of calling those events. this makes implementation of Mapview cleaner within the developer's codebase and not having to worry if they called the mapview lifecyle events e.g. onDestroy in Activity:Ondestroy. The only requirement is that you call the new MapView::attachLifeCycle method when you bind your MapView.java


</changelog>`



