### PR TITLE
[deps] Bump telemetry library to v6.2.0, core library to v3.1.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,8 +8,8 @@ ext {
 
     versions = [
             mapboxServices   : '5.3.0',
-            mapboxTelemetry  : '6.1.0',
-            mapboxCore       : '3.0.0',
+            mapboxTelemetry  : '6.2.0',
+            mapboxCore       : '3.1.0',
             mapboxGestures   : '0.7.0',
             mapboxAccounts   : '0.7.0',
             appCompat        : '1.0.0',


### PR DESCRIPTION
`<changelog>Bump telemetry library to v6.2.0 and core library to v3.1.0.</changelog>`

<!-- Examples: -->
<!-- `<changelog>Enabled reusing objects with `Projection.getVisibleCoordinateBounds`.</changelog>` -->
<!-- `<changelog>Added an option to set the minimum and maximum pitch of a `Map`.</changelog>`-->
<!-- `<changelog>Introduced `in` expression for testing whether an item exists in an array or a substring exists in a string.</changelog>`
<!-- `<changelog>Significantly improved offline pack download performance by marking resources as used in batches.</changelog>`
<!-- `<changelog>Fixed a bug where non-overlapping symbols would be sorted incorrectly with `SymbolLayer.symbolSortKey`.</changelog>` -->


