### PR TITLE
[deps] Bump gl-core to v5.1.0, sdk-registry plugin to v0.3.0.

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -40,8 +40,8 @@ ext {
             ktlint           : '0.34.0',
             commonsIO        : '2.6',
             mapboxSdkVersions: '1.1.0',
-            mapboxSdkCore    : '5.0.0',
-            mapboxSdkRegistryPlugin: '0.2.1'
+            mapboxSdkCore    : '5.1.0',
+            mapboxSdkRegistryPlugin: '0.3.0'
     ]
 
     dependenciesList = [


### PR DESCRIPTION
`<changelog>Update core library to 5.1.0/changelog>`

<!-- Examples: -->
<!-- `<changelog>Enabled reusing objects with `Projection.getVisibleCoordinateBounds`.</changelog>` -->
<!-- `<changelog>Added an option to set the minimum and maximum pitch of a `Map`.</changelog>`-->
<!-- `<changelog>Introduced `in` expression for testing whether an item exists in an array or a substring exists in a string.</changelog>`
<!-- `<changelog>Significantly improved offline pack download performance by marking resources as used in batches.</changelog>`
<!-- `<changelog>Fixed a bug where non-overlapping symbols would be sorted incorrectly with `SymbolLayer.symbolSortKey`.</changelog>` -->


