### PR TITLE
[build] Add scripts to manually publish to SDK-Registry.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,6 +245,12 @@ run-android-test-app-center:
 run-android-upload-to-sdk-registry: gradle/configuration.gradle
 	$(MBGL_ANDROID_GRADLE) -Pmapbox.abis=all :MapboxGLAndroidSDK:mapboxSDKRegistryUpload
 
+# Publishes the Android SDK to Mapbox SDK Registry
+.PHONY: run-android-publish-to-sdk-registry
+run-android-publish-to-sdk-registry: gradle/configuration.gradle
+	python3 -m pip install git-pull-request
+	$(MBGL_ANDROID_GRADLE) -Pmapbox.abis=all :MapboxGLAndroidSDK:mapboxSDKRegistryPublish
+
 # Dump system graphics information for the test app
 .PHONY: android-gfxinfo
 android-gfxinfo:
@@ -321,14 +327,6 @@ run-android-nitpick: android-update-vendor
 android-graph: gradle/configuration.gradle
 	$(MBGL_ANDROID_GRADLE) -Pmapbox.abis=none :MapboxGLAndroidSDK:generateDependencyGraphMapboxLibraries
 
-.PHONY: sdk-registry-upload
-sdk-registry-upload: gradle/configuration.gradle
-	$(MBGL_ANDROID_GRADLE) -Pmapbox.abis=none :MapboxGLAndroidSDK:mapboxSDKRegistryUpload
-
-.PHONY: sdk-registry-publish
-sdk-registry-publish: gradle/configuration.gradle
-	python3 -m pip install git-pull-request
-	$(MBGL_ANDROID_GRADLE) -Pmapbox.abis=none :MapboxGLAndroidSDK:mapboxSDKRegistryPublish
 #### Miscellaneous targets #####################################################
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -321,6 +321,14 @@ run-android-nitpick: android-update-vendor
 android-graph: gradle/configuration.gradle
 	$(MBGL_ANDROID_GRADLE) -Pmapbox.abis=none :MapboxGLAndroidSDK:generateDependencyGraphMapboxLibraries
 
+.PHONY: sdk-registry-upload
+sdk-registry-upload: gradle/configuration.gradle
+	$(MBGL_ANDROID_GRADLE) -Pmapbox.abis=none :MapboxGLAndroidSDK:mapboxSDKRegistryUpload
+
+.PHONY: sdk-registry-publish
+sdk-registry-publish: gradle/configuration.gradle
+	python3 -m pip install git-pull-request
+	$(MBGL_ANDROID_GRADLE) -Pmapbox.abis=none :MapboxGLAndroidSDK:mapboxSDKRegistryPublish
 #### Miscellaneous targets #####################################################
 
 .PHONY: clean

--- a/MapboxGLAndroidSDK/gradle.properties
+++ b/MapboxGLAndroidSDK/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=9.5.0
+VERSION_NAME=9.6.0-alpha.1
 
 # Only build native dependencies for the current ABI
 # See https://code.google.com/p/android/issues/detail?id=221098#c20

--- a/MapboxGLAndroidSDK/src/main/assets/sdk_versions/com.mapbox.mapboxsdk
+++ b/MapboxGLAndroidSDK/src/main/assets/sdk_versions/com.mapbox.mapboxsdk
@@ -1,2 +1,2 @@
-MapboxGLAndroidSDK/9.5.0
+MapboxGLAndroidSDK/9.6.0-alpha.1
 v-1

--- a/gradle/gradle-sdk-registry.gradle
+++ b/gradle/gradle-sdk-registry.gradle
@@ -49,6 +49,7 @@ registry {
     snapshot = false
     override = false
     dryRun = false
+    publish = true
     publications = ["MapboxAndroidMapsSdk"]
 }
 


### PR DESCRIPTION
This PR adds scripts to manually publish to SDK-Registry.

<!-- Examples: -->
<!-- `<changelog>Enabled reusing objects with `Projection.getVisibleCoordinateBounds`.</changelog>` -->
<!-- `<changelog>Added an option to set the minimum and maximum pitch of a `Map`.</changelog>`-->
<!-- `<changelog>Introduced `in` expression for testing whether an item exists in an array or a substring exists in a string.</changelog>`
<!-- `<changelog>Significantly improved offline pack download performance by marking resources as used in batches.</changelog>`
<!-- `<changelog>Fixed a bug where non-overlapping symbols would be sorted incorrectly with `SymbolLayer.symbolSortKey`.</changelog>` -->


