### PR TITLE
[compass] - deprecate bitmap API, use drawable resource ID API 

### DIFF
--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
@@ -225,6 +225,7 @@ public class MapboxConstants {
   public static final String STATE_COMPASS_MARGIN_BOTTOM = "mapbox_compassMarginBottom";
   public static final String STATE_COMPASS_FADE_WHEN_FACING_NORTH = "mapbox_compassFade";
   public static final String STATE_COMPASS_IMAGE_BITMAP = "mapbox_compassImage";
+  public static final String STATE_COMPASS_IMAGE_RES = "mapbox_compassImageRes";
   public static final String STATE_LOGO_GRAVITY = "mapbox_logoGravity";
   public static final String STATE_LOGO_MARGIN_LEFT = "mapbox_logoMarginLeft";
   public static final String STATE_LOGO_MARGIN_TOP = "mapbox_logoMarginTop";

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
@@ -9,11 +9,11 @@ import android.os.Parcel;
 import android.os.Parcelable;
 
 import androidx.annotation.ColorInt;
+import androidx.annotation.DrawableRes;
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
-import androidx.core.content.res.ResourcesCompat;
 
 import android.text.TextUtils;
 import android.util.AttributeSet;
@@ -50,6 +50,8 @@ public class MapboxMapOptions implements Parcelable {
   private boolean fadeCompassFacingNorth = true;
   private int compassGravity = Gravity.TOP | Gravity.END;
   private int[] compassMargins;
+  @DrawableRes
+  private int compassImageResource;
   private Drawable compassImage;
 
   private boolean logoEnabled = true;
@@ -117,6 +119,7 @@ public class MapboxMapOptions implements Parcelable {
     if (compassBitmap != null) {
       compassImage = new BitmapDrawable(compassBitmap);
     }
+    compassImageResource = in.readInt();
 
     logoEnabled = in.readByte() != 0;
     logoGravity = in.readInt();
@@ -233,12 +236,12 @@ public class MapboxMapOptions implements Parcelable {
           FOUR_DP * pxlRatio))});
       mapboxMapOptions.compassFadesWhenFacingNorth(typedArray.getBoolean(
         R.styleable.mapbox_MapView_mapbox_uiCompassFadeFacingNorth, true));
-      Drawable compassDrawable = typedArray.getDrawable(
-        R.styleable.mapbox_MapView_mapbox_uiCompassDrawable);
-      if (compassDrawable == null) {
-        compassDrawable = ResourcesCompat.getDrawable(context.getResources(), R.drawable.mapbox_compass_icon, null);
-      }
+
+      Drawable compassDrawable = typedArray.getDrawable(R.styleable.mapbox_MapView_mapbox_uiCompassDrawable);
       mapboxMapOptions.compassImage(compassDrawable);
+      mapboxMapOptions.compassImageResource(
+        typedArray.getInt(R.styleable.mapbox_MapView_mapbox_uiCompassDrawableRes, R.drawable.mapbox_compass_icon)
+      );
 
       mapboxMapOptions.logoEnabled(typedArray.getBoolean(R.styleable.mapbox_MapView_mapbox_uiLogo, true));
       mapboxMapOptions.logoGravity(typedArray.getInt(R.styleable.mapbox_MapView_mapbox_uiLogoGravity,
@@ -470,10 +473,26 @@ public class MapboxMapOptions implements Parcelable {
    *
    * @param compass the drawable to show as image compass
    * @return This
+   * @deprecated use {@link #compassImageResource} instead
    */
   @NonNull
   public MapboxMapOptions compassImage(Drawable compass) {
     this.compassImage = compass;
+    return this;
+  }
+
+  /**
+   * Specifies the image of the CompassView.
+   * <p>
+   * By default this value is R.drawable.mapbox_compass_icon.
+   * </p>
+   *
+   * @param compassImageResource the drawable resource id to show as image compass
+   * @return This
+   */
+  @NonNull
+  public MapboxMapOptions compassImageResource(@DrawableRes int compassImageResource) {
+    this.compassImageResource = compassImageResource;
     return this;
   }
 
@@ -946,8 +965,19 @@ public class MapboxMapOptions implements Parcelable {
    *
    * @return the drawable used as compass image
    */
+  @Deprecated
   public Drawable getCompassImage() {
     return compassImage;
+  }
+
+  /**
+   * Get the current configured CompassView image resource id.
+   *
+   * @return the resource id of the used as compass image
+   */
+  @DrawableRes
+  public int getCompassImageResource() {
+    return compassImageResource;
   }
 
   /**
@@ -1171,7 +1201,7 @@ public class MapboxMapOptions implements Parcelable {
     dest.writeByte((byte) (fadeCompassFacingNorth ? 1 : 0));
     dest.writeParcelable(compassImage != null
       ? BitmapUtils.getBitmapFromDrawable(compassImage) : null, flags);
-
+    dest.writeInt(compassImageResource);
     dest.writeByte((byte) (logoEnabled ? 1 : 0));
     dest.writeInt(logoGravity);
     dest.writeIntArray(logoMargins);
@@ -1231,6 +1261,9 @@ public class MapboxMapOptions implements Parcelable {
     if (compassImage != null
       ? !compassImage.equals(options.compassImage)
       : options.compassImage != null) {
+      return false;
+    }
+    if (compassImageResource != options.compassImageResource) {
       return false;
     }
     if (compassGravity != options.compassGravity) {
@@ -1339,6 +1372,7 @@ public class MapboxMapOptions implements Parcelable {
     result = 31 * result + (fadeCompassFacingNorth ? 1 : 0);
     result = 31 * result + compassGravity;
     result = 31 * result + (compassImage != null ? compassImage.hashCode() : 0);
+    result = 31 * result + compassImageResource;
     result = 31 * result + Arrays.hashCode(compassMargins);
     result = 31 * result + (logoEnabled ? 1 : 0);
     result = 31 * result + logoGravity;

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/CompassView.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/CompassView.java
@@ -2,6 +2,8 @@ package com.mapbox.mapboxsdk.maps.widgets;
 
 import android.content.Context;
 import android.graphics.drawable.Drawable;
+
+import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.view.ViewCompat;
@@ -35,6 +37,9 @@ public final class CompassView extends ImageView implements Runnable {
   private ViewPropertyAnimatorCompat fadeAnimator;
   private MapboxMap.OnCompassAnimationListener compassAnimationListener;
   private boolean isAnimating = false;
+  @DrawableRes
+  private int compassImageResource;
+  private boolean legacyImageDrawableSetter = false;
 
   public CompassView(@NonNull Context context) {
     super(context);
@@ -139,8 +144,10 @@ public final class CompassView extends ImageView implements Runnable {
    * Set the CompassView image.
    *
    * @param compass the drawable to use as compass image
+   * @deprecated use {@link #setCompassImageResource(int)} instead
    */
   public void setCompassImage(Drawable compass) {
+    legacyImageDrawableSetter = true;
     setImageDrawable(compass);
   }
 
@@ -148,6 +155,7 @@ public final class CompassView extends ImageView implements Runnable {
    * Get the current configured CompassView image.
    *
    * @return the drawable used as compass image
+   * @deprecated use {@link #getCompassImageResource()} instead
    */
   public Drawable getCompassImage() {
     return getDrawable();
@@ -175,5 +183,18 @@ public final class CompassView extends ImageView implements Runnable {
     if (isAnimating) {
       compassAnimationListener.onCompassAnimation();
     }
+  }
+
+  public int getCompassImageResource() {
+    return compassImageResource;
+  }
+
+  public void setCompassImageResource(int drawableRes) {
+    this.compassImageResource = drawableRes;
+    setImageResource(compassImageResource);
+  }
+
+  public boolean isLegacyImageDrawableSetter() {
+    return legacyImageDrawableSetter;
   }
 }

--- a/MapboxGLAndroidSDK/src/main/res-public/values/public.xml
+++ b/MapboxGLAndroidSDK/src/main/res-public/values/public.xml
@@ -50,6 +50,7 @@
     <public name="mapbox_uiCompassMarginBottom" type="attr" />
     <public name="mapbox_uiCompassFadeFacingNorth" type="attr" />
     <public name="mapbox_uiCompassDrawable" type="attr" />
+    <public name="mapbox_uiCompassDrawableRes" type="attr" />
 
     <!--Logo-->
     <public name="mapbox_uiLogo" type="attr" />

--- a/MapboxGLAndroidSDK/src/main/res/values/attrs.xml
+++ b/MapboxGLAndroidSDK/src/main/res/values/attrs.xml
@@ -60,6 +60,7 @@
         <attr name="mapbox_uiCompassMarginBottom" format="dimension"/>
         <attr name="mapbox_uiCompassFadeFacingNorth" format="boolean"/>
         <attr name="mapbox_uiCompassDrawable" format="reference"/>
+        <attr name="mapbox_uiCompassDrawableRes" format="integer"/>
 
         <!--Logo-->
         <attr name="mapbox_uiLogo" format="boolean"/>


### PR DESCRIPTION
`<changelog>[compass] deprecate bitmap API, introduce drawable resource ID API instead.</changelog>`
