### PR TITLE
[docs] update changelog for v8.6.7 release (#606)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,20 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [`Contributing Guide`](https://github.com/mapbox/mapbox-gl-native/blob/master/CONTRIBUTING.md) to get started.
 
-## 8.6.6 - September 25, 2020
-[Changes](https://github.com/mapbox/mapbox-gl-native-android/compare/android-v8.6.5...android-v8.6.6) since [Mapbox Maps SDK for Android v8.6.5](https://github.com/mapbox/mapbox-gl-native-android/releases/tag/android-v8.6.5):
+## 8.6.7 - October 22, 2020
+[Changes](https://github.com/mapbox/mapbox-gl-native-android/compare/android-v8.6.6...android-v8.6.7) since [Mapbox Maps SDK for Android v8.6.6](https://github.com/mapbox/mapbox-gl-native-android/releases/tag/android-v8.6.6):
 ### Bug fixes
- - Fix Style not ready exception in location component ([#563](https://github.com/mapbox/mapbox-gl-native-android/pull/563))
+ - Compass, deprecate bitmap API, introduce drawable resource ID API instead ([#598](https://github.com/mapbox/mapbox-gl-native-android/pull/598))
 
-## 9.5.0-beta.1 - September 14, 2020
-[Changes](https://github.com/mapbox/mapbox-gl-native-android/compare/android-v9.4.0...android-v9.5.0-beta.1) since [Mapbox Maps SDK for Android 9.4.0](https://github.com/mapbox/mapbox-gl-native-android/releases/tag/android-v9.4.0)
-### Improvements and bug fixes 
+## 9.6.0-alpha.1 - October 7, 2020
+[Changes](https://github.com/mapbox/mapbox-gl-native-android/compare/android-v9.5.0...android-v9.6.0-alpha.1) since [Mapbox Maps SDK for Android 9.5.0](https://github.com/mapbox/mapbox-gl-native-android/releases/tag/android-v9.5.0)
+### Dependencies
+ - Update telemetry to 6.2.0
+ - Update core library to 5.1.0
+
+## 9.5.0 - September 25, 2020
+[Changes](https://github.com/mapbox/mapbox-gl-native-android/compare/android-v9.4.0...android-v9.5.0) since [Mapbox Maps SDK for Android 9.4.0](https://github.com/mapbox/mapbox-gl-native-android/releases/tag/android-v9.4.0)
+### Improvements and bug fixes
  - Fix crash when converting screen coordinate as part of moveBy ([#555](https://github.com/mapbox/mapbox-gl-native-android/pull/555))
  - Upgrade MapView to manage multiple OnTouchListener-s ([#511](https://github.com/mapbox/mapbox-gl-native-android/pull/511))
  - Remove `LocalGlyphRasterizer`, now it's a part of core as pure C++ implementation. ([#548](https://github.com/mapbox/mapbox-gl-native-android/pull/548))
@@ -17,7 +23,12 @@ Mapbox welcomes participation and contributions from everyone. Please read [`Con
  - `LocationPropertyFactory`: `imageTiltDisplacement` methods are deprecated, `imagePitchDisplacement` are introduced for replacement. ([#548](https://github.com/mapbox/mapbox-gl-native-android/pull/548))
 ### Dependencies
  - Update core library to 5.0.0
- 
+
+## 8.6.6 - September 25, 2020
+[Changes](https://github.com/mapbox/mapbox-gl-native-android/compare/android-v8.6.5...android-v8.6.6) since [Mapbox Maps SDK for Android v8.6.5](https://github.com/mapbox/mapbox-gl-native-android/releases/tag/android-v8.6.5):
+### Bug fixes
+ - Fix Style not ready exception in location component ([#563](https://github.com/mapbox/mapbox-gl-native-android/pull/563))
+
 ## 9.4.0 - August 26, 2020
 [Changes](https://github.com/mapbox/mapbox-gl-native-android/compare/android-v9.3.0...android-v9.4.0) since [Mapbox Maps SDK for Android v9.3.0](https://github.com/mapbox/mapbox-gl-native-android/releases/tag/android-v9.3.0)
 ### Features
@@ -34,7 +45,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [`Con
 ### Dependencies
  - Update telemetry to 6.1.0
  - Update core library to 3.1.0
- 
+
 ## 9.3.1 - July 25, 2020
 ### Bug fixes
  - Fix crash on old devices (Android 4.4) related to LLD linker.


### PR DESCRIPTION
Cherry-pick of https://github.com/mapbox/mapbox-gl-native-android/pull/606 to release-tequila for the v8.6.7 release.


