### PR TITLE
[android] - trigger exception when onCreate is not called

### DIFF
--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/exceptions/MapboxLifecycleException.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/exceptions/MapboxLifecycleException.java
@@ -1,0 +1,22 @@
+package com.mapbox.mapboxsdk.exceptions;
+
+import android.content.Context;
+
+/**
+ * A MapboxLifecycleException is thrown by MapView when it's lifecycle hasn't been properly integrated.
+ * <p>
+ * This occurs either when {@link com.mapbox.mapboxsdk.Mapbox} is not correctly initialised or the provided access token
+ * through {@link com.mapbox.mapboxsdk.Mapbox#getInstance(Context, String)} isn't valid.
+ * </p>
+ *
+ * @see com.mapbox.mapboxsdk.Mapbox#getInstance(Context, String)
+ */
+public class MapboxLifecycleException extends RuntimeException {
+
+  /**
+   * Creates a Mapbox lifecycle exception thrown by MapView when it's lifecycle hasn't been properly integrated.
+   */
+  public MapboxLifecycleException() {
+    super("MapView requires calling the correct Activity lifecycle methods: onCreate, onStart, onStop and onDestroy.");
+  }
+}

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -27,6 +27,7 @@ import com.mapbox.mapboxsdk.R;
 import com.mapbox.mapboxsdk.annotations.Annotation;
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
 import com.mapbox.mapboxsdk.exceptions.MapboxConfigurationException;
+import com.mapbox.mapboxsdk.exceptions.MapboxLifecycleException;
 import com.mapbox.mapboxsdk.location.LocationComponent;
 import com.mapbox.mapboxsdk.maps.renderer.MapRenderer;
 import com.mapbox.mapboxsdk.maps.renderer.glsurfaceview.GLSurfaceViewMapRenderer;
@@ -77,6 +78,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   private AttributionClickListener attributionClickListener;
   MapboxMapOptions mapboxMapOptions;
   private MapRenderer mapRenderer;
+  private boolean created;
   private boolean destroyed;
 
   @Nullable
@@ -299,6 +301,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
    */
   @UiThread
   public void onCreate(@Nullable Bundle savedInstanceState) {
+    created = true;
     if (savedInstanceState == null) {
       TelemetryDefinition telemetry = Mapbox.getTelemetry();
       if (telemetry != null) {
@@ -380,11 +383,16 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
    */
   @UiThread
   public void onStart() {
+    if (!created) {
+      throw new MapboxLifecycleException();
+    }
+
     if (!isStarted) {
       ConnectivityReceiver.instance(getContext()).activate();
       FileSource.getInstance(getContext()).activate();
       isStarted = true;
     }
+
     if (mapboxMap != null) {
       mapboxMap.onStart();
     }

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/NoStyleActivity.kt
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/NoStyleActivity.kt
@@ -26,6 +26,7 @@ class NoStyleActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_map_simple)
+    mapView.onCreate(savedInstanceState)
     mapView.getMapAsync { map ->
       map.moveCamera(CameraUpdateFactory.newLatLngZoom(cameraTarget, cameraZoom))
       map.setStyle(

--- a/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/textureview/TextureViewAnimationActivity.java
+++ b/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/textureview/TextureViewAnimationActivity.java
@@ -56,6 +56,7 @@ public class TextureViewAnimationActivity extends AppCompatActivity {
 
   private void setupMapView(Bundle savedInstanceState) {
     mapView = (MapView) findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
     mapView.getMapAsync(mapboxMap -> {
       TextureViewAnimationActivity.this.mapboxMap = mapboxMap;
 


### PR DESCRIPTION
This PR adds a flag and exception to validate onCreate was correctly called. OnStart has to be called to be able to render a map, throwing from that method looked like the most valid code path to validate if OnCreate was called.