### PR TITLE
Update telemetry to 6.2.2 and core 3.1.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,8 +8,8 @@ ext {
 
     versions = [
             mapboxServices   : '5.3.0',
-            mapboxTelemetry  : '6.2.0',
-            mapboxCore       : '3.1.0',
+            mapboxTelemetry  : '6.2.2',
+            mapboxCore       : '3.1.1',
             mapboxGestures   : '0.7.0',
             mapboxAccounts   : '0.7.0',
             appCompat        : '1.0.0',


### PR DESCRIPTION
This PR updates telemetry to v6.2.2:
https://github.com/mapbox/mapbox-events-android/releases/tag/telem-6.2.2
And Android core to v3.1.1:
https://github.com/mapbox/mapbox-events-android/releases/tag/core-3.1.1