### PR TITLE
[deps] update telemetry to 8.1.0 (okhttp3 variant) and events-core 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [`Contributing Guide`](https://github.com/mapbox/mapbox-gl-native/blob/master/CONTRIBUTING.md) to get started.
 
+## 9.6.2 - July 7, 2021
+[Changes](https://github.com/mapbox/mapbox-gl-native-android/compare/android-v9.6.1...android-v9.6.2) since [Mapbox Maps SDK for Android 9.6.1](https://github.com/mapbox/mapbox-gl-native-android/releases/tag/android-v9.6.0)
+### Dependencies
+ - Update telemetry to 8.1.0 (okhttp3 variant) and events-core 5.0.0 to make project compatible with Android 12
+
 ## 9.6.1 - February 9, 2021
 [Changes](https://github.com/mapbox/mapbox-gl-native-android/compare/android-v9.6.0...android-v9.6.1) since [Mapbox Maps SDK for Android 9.6.0](https://github.com/mapbox/mapbox-gl-native-android/releases/tag/android-v9.6.0)
 ### Improvements and bug fixes

--- a/MapboxGLAndroidSDK/build.gradle
+++ b/MapboxGLAndroidSDK/build.gradle
@@ -6,6 +6,7 @@ apply plugin: 'com.mapbox.android.sdk.versions'
 dependencies {
     lintChecks project(":MapboxGLAndroidSDKLint")
     api dependenciesList.mapboxAndroidTelemetry
+    api dependenciesList.mapboxAndroidCore
     api dependenciesList.mapboxJavaGeoJSON
     api dependenciesList.mapboxAndroidGestures
     api dependenciesList.mapboxAndroidAccounts

--- a/MapboxGLAndroidSDKTestApp/build.gradle
+++ b/MapboxGLAndroidSDKTestApp/build.gradle
@@ -66,6 +66,8 @@ dependencies {
     implementation dependenciesList.supportDesign
     implementation dependenciesList.supportConstraintLayout
 
+    implementation dependenciesList.okio
+    implementation dependenciesList.okhttp3
     implementation dependenciesList.gmsLocation
     implementation dependenciesList.timber
     debugImplementation dependenciesList.leakCanaryDebug

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,8 +8,8 @@ ext {
 
     versions = [
             mapboxServices   : '5.3.0',
-            mapboxTelemetry  : '6.2.2',
-            mapboxCore       : '3.1.1',
+            mapboxTelemetry  : '8.1.0',
+            mapboxCore       : '5.0.0',
             mapboxGestures   : '0.7.0',
             mapboxAccounts   : '0.7.0',
             appCompat        : '1.0.0',
@@ -41,13 +41,15 @@ ext {
             commonsIO        : '2.6',
             mapboxSdkVersions: '1.1.0',
             mapboxSdkCore    : '5.2.2',
-            mapboxSdkRegistryPlugin: '0.3.0'
+            mapboxSdkRegistryPlugin: '0.3.0',
+            okio             : '2.4.3'
     ]
 
     dependenciesList = [
             mapboxSdkCore          : "com.mapbox.mapboxsdk:mapbox-android-sdk-gl-core:${versions.mapboxSdkCore}",
             mapboxJavaGeoJSON      : "com.mapbox.mapboxsdk:mapbox-sdk-geojson:${versions.mapboxServices}",
-            mapboxAndroidTelemetry : "com.mapbox.mapboxsdk:mapbox-android-telemetry:${versions.mapboxTelemetry}",
+            mapboxAndroidTelemetry : "com.mapbox.mapboxsdk:mapbox-android-telemetry-okhttp3:${versions.mapboxTelemetry}",
+            mapboxAndroidCore      : "com.mapbox.mapboxsdk:mapbox-android-core:${versions.mapboxCore}",
             mapboxAndroidGestures  : "com.mapbox.mapboxsdk:mapbox-android-gestures:${versions.mapboxGestures}",
             mapboxAndroidAccounts  : "com.mapbox.mapboxsdk:mapbox-android-accounts:${versions.mapboxAccounts}",
             mapboxJavaTurf         : "com.mapbox.mapboxsdk:mapbox-sdk-turf:${versions.mapboxServices}",
@@ -77,6 +79,7 @@ ext {
             gmsLocation            : "com.google.android.gms:play-services-location:${versions.gms}",
             timber                 : "com.jakewharton.timber:timber:${versions.timber}",
             okhttp3                : "com.squareup.okhttp3:okhttp:${versions.okhttp}",
+            okio                   : "com.squareup.okio:okio:${versions.okio}",
             leakCanaryDebug        : "com.squareup.leakcanary:leakcanary-android:${versions.leakCanary}",
             leakCanaryRelease      : "com.squareup.leakcanary:leakcanary-android-no-op:${versions.leakCanary}",
 


### PR DESCRIPTION
This PR updates telemetry to 8.1.0 and the underlying events core library to 5.0.0. 
These changes are required to be compatible with Android 12 (eta September). 
As tailwork of this PR, we need to verify if we can compile and run against Android 12. 