### PR TITLE
minor license file fixes -- deduplication & links

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -212,7 +212,7 @@ License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox Maps SDK for Android uses portions of Okio.  
+Mapbox Maps SDK for Android uses portions of [Okio](https://github.com/square/okio).  
 License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -112,12 +112,6 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 ===========================================================================
 
-Mapbox Maps SDK for Android uses portions of Android Support Library Custom View.  
-URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
-License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-===========================================================================
-
 Mapbox Maps SDK for Android uses portions of Android Support Library Document File.  
 URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -166,7 +166,7 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 ===========================================================================
 
-Mapbox Maps SDK for Android uses portions of Gson.  
+Mapbox Maps SDK for Android uses portions of [Gson](https://github.com/google/gson).  
 License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -201,12 +201,6 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 ===========================================================================
 
-Mapbox Maps SDK for Android uses portions of Mapbox Java SDK.  
-URL: [https://github.com/mapbox/mapbox-java](https://github.com/mapbox/mapbox-java)  
-License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-===========================================================================
-
 Mapbox Maps SDK for Android uses portions of Mapbox Maps GL Core SDK for Android.  
 URL: [https://github.com/mapbox/mapbox-gl-native-android](https://github.com/mapbox/mapbox-gl-native-android)  
 License: [BSD](https://opensource.org/licenses/BSD-2-Clause)

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -207,7 +207,7 @@ License: [BSD](https://opensource.org/licenses/BSD-2-Clause)
 
 ===========================================================================
 
-Mapbox Maps SDK for Android uses portions of OkHttp.  
+Mapbox Maps SDK for Android uses portions of [OkHttp](https://square.github.io/okhttp/).  
 License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================

--- a/circle.yml
+++ b/circle.yml
@@ -196,7 +196,7 @@ jobs:
         default: sailfish
       firebase_device_os:
         type: string
-        default: "26"
+        default: "25"
       abi:
         type: string
         default: "arm-v8"
@@ -312,7 +312,7 @@ jobs:
               if [[ $CIRCLE_BRANCH != main && $CIRCLE_TAG != android-v* ]]; then
                 gcloud firebase test android run --type robo \
                   --app MapboxGLAndroidSDKTestApp/build/outputs/apk/release/MapboxGLAndroidSDKTestApp-release.apk \
-                  --device-ids sailfish --os-version-ids "26" --locales en --orientations portrait --timeout 90s
+                  --device-ids sailfish --os-version-ids "25" --locales en --orientations portrait --timeout 90s
               fi
             fi
       - store_artifacts:

--- a/gradle/android-nitpick.gradle
+++ b/gradle/android-nitpick.gradle
@@ -19,8 +19,6 @@ task androidNitpick {
         verifyVendorSubmodulePin(MAPBOX_TELEMETRY_DIR, MAPBOX_TELEMETRY_TAG_PREFIX,
                 versions.mapboxTelemetry + MAPBOX_CORE_TAG_PREFIX + versions.mapboxCore)
         verifyVendorSubmodulePin(MAPBOX_GESTURES_DIR, MAPBOX_GESTURES_TAG_PREFIX, versions.mapboxGestures)
-
-        verifyLicenseGeneration()
     }
 }
 
@@ -55,12 +53,4 @@ private def verifyVendorSubmodulePin(def dir, def prefix, def version) {
                 "If you've bumped the pin, make sure to verify the version tag prefix in the android-nitpick.gradle file.")
     }
     output.close()
-}
-
-private def verifyLicenseGeneration() {
-    println "Verify license generation with git diff..."
-    exec {
-        workingDir = "${rootDir}"
-        commandLine "python", "scripts/validate-license.py"
-    }
 }


### PR DESCRIPTION
Removes two duplicate items and links `okio`, `okhttp` and `gson` projects to their repos (and license files).

cc:
- [x] @tobrun for eng review
- [ ] @ectrotter for legal review

note: there's tons of trailing whitespace in here. I didn't fix to keep the PR readable. Will clean up once this is merged.