### PR TITLE
Fix the race condition when updating LocationCompoent's position.

### DIFF
--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/SymbolLocationLayerRenderer.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/SymbolLocationLayerRenderer.java
@@ -343,7 +343,7 @@ final class SymbolLocationLayerRenderer implements LocationLayerRenderer {
 
     GeoJsonSource source = style.getSourceAs(LOCATION_SOURCE);
     if (source != null) {
-      locationSource.setGeoJson(locationFeature);
+      locationSource.setGeoJson(locationFeature.toJson());
     }
   }
 

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/GeoJsonSource.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/GeoJsonSource.java
@@ -256,6 +256,9 @@ public class GeoJsonSource extends Source {
    * Updates the GeoJson with a single feature. The update is performed asynchronously,
    * so the data won't be immediately visible or available to query when this method returns.
    *
+   * Note: This method is not thread-safe. The Feature is parsed on a worker thread, please make sure
+   * the Feature is immutable.
+   *
    * @param feature the GeoJSON {@link Feature} to set
    */
   public void setGeoJson(Feature feature) {
@@ -270,6 +273,9 @@ public class GeoJsonSource extends Source {
    * Updates the GeoJson with a single geometry. The update is performed asynchronously,
    * so the data won't be immediately visible or available to query when this method returns.
    *
+   * Note: This method is not thread-safe. The Geometry is parsed on a worker thread, please make sure
+   * the Geometry is immutable.
+   *
    * @param geometry the GeoJSON {@link Geometry} to set
    */
   public void setGeoJson(Geometry geometry) {
@@ -283,6 +289,9 @@ public class GeoJsonSource extends Source {
   /**
    * Updates the GeoJson. The update is performed asynchronously,
    * so the data won't be immediately visible or available to query when this method returns.
+   *
+   * Note: This method is not thread-safe. The FeatureCollection is parsed on a worker thread, please make sure
+   * the FeatureCollection is immutable.
    *
    * @param featureCollection the GeoJSON FeatureCollection
    */

--- a/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationLayerControllerTest.java
+++ b/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/location/LocationLayerControllerTest.java
@@ -536,6 +536,7 @@ public class LocationLayerControllerTest {
     LayerBitmapProvider bitmapProvider = mock(LayerBitmapProvider.class);
     LocationComponentOptions options = mock(LocationComponentOptions.class);
     Feature locationFeature = mock(Feature.class);
+    when(locationFeature.toJson()).thenReturn("expected_geojson_string");
     LocationLayerController layer = new LocationLayerController(
       mapboxMap, mapboxMap.getStyle(), sourceProvider, buildFeatureProvider(locationFeature, options),
       bitmapProvider, options, internalRenderModeChangedListener, internalIndicatorPositionChangedListener, false);
@@ -543,7 +544,7 @@ public class LocationLayerControllerTest {
     getAnimationListener(ANIMATOR_LAYER_LATLNG, layer.getAnimationListeners()).onNewAnimationValue(new LatLng());
 
     // wanted twice (once for initialization)
-    verify(locationSource, times(2)).setGeoJson(locationFeature);
+    verify(locationSource, times(2)).setGeoJson("expected_geojson_string");
     verify(internalIndicatorPositionChangedListener).onIndicatorPositionChanged(any(Point.class));
   }
 


### PR DESCRIPTION
This PR fixes the race condition when updating LocationCompoent's position.
This PR also adds documentation to the `GeoJsonSource#setGeoJson`, stating the method is not thread-safe.

When using SymbolLayer and GeoJsonSource backed location puck, there's high frequency
modifications done on the main thread and locationFeature is always re-used (modified)
while being parsed on the worker thread. As the `GeoJsonSource#setGeoJson` method is not thread-safe,
we should do a deep copy of the location feature before passing setting it to GeoJsonSource.

`<changelog>Fix the race condition when updating LocationCompoent's position.</changelog>`

