### PR TITLE
Add OnDidFailLoadingTileListener.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,16 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [`Contributing Guide`](https://github.com/mapbox/mapbox-gl-native/blob/master/CONTRIBUTING.md) to get started.
 
+## 9.7.0 - September 24, 2021
+[Changes](https://github.com/mapbox/mapbox-gl-native-android/compare/android-v9.6.2...android-v9.7.0) since [Mapbox Maps SDK for Android 9.6.2](https://github.com/mapbox/mapbox-gl-native-android/releases/tag/android-v9.6.2)
+### Improvements and bug fixes
+ - Fix the race condition when updating LocationCompoent's position. ([#703](https://github.com/mapbox/mapbox-gl-native-android/pull/703))
+ - Handle exceptions thrown at layout initialization (including those thrown from vector tile parsing) and add `OnDidFailLoadingTileListener`, which will be trigged when tile failed to load. ([#704](https://github.com/mapbox/mapbox-gl-native-android/pull/704))
+### Dependencies
+ - Update core library to 5.3.0
+
 ## 9.6.2 - July 7, 2021
-[Changes](https://github.com/mapbox/mapbox-gl-native-android/compare/android-v9.6.1...android-v9.6.2) since [Mapbox Maps SDK for Android 9.6.1](https://github.com/mapbox/mapbox-gl-native-android/releases/tag/android-v9.6.0)
+[Changes](https://github.com/mapbox/mapbox-gl-native-android/compare/android-v9.6.1...android-v9.6.2) since [Mapbox Maps SDK for Android 9.6.1](https://github.com/mapbox/mapbox-gl-native-android/releases/tag/android-v9.6.1)
 ### Dependencies
  - Update telemetry to 8.1.0 (okhttp3 variant) and events-core 5.0.0 to make project compatible with Android 12
 

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapChangeReceiver.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapChangeReceiver.java
@@ -18,6 +18,8 @@ class MapChangeReceiver implements NativeMapView.StateCallback {
     = new CopyOnWriteArrayList<>();
   private final List<MapView.OnDidFailLoadingMapListener> onDidFailLoadingMapListenerList
     = new CopyOnWriteArrayList<>();
+  private final List<MapView.OnDidFailLoadingTileListener> onDidFailLoadingTileListenerList
+    = new CopyOnWriteArrayList<>();
   private final List<MapView.OnWillStartRenderingFrameListener> onWillStartRenderingFrameList
     = new CopyOnWriteArrayList<>();
   private final List<MapView.OnDidFinishRenderingFrameListener> onDidFinishRenderingFrameList
@@ -112,6 +114,20 @@ class MapChangeReceiver implements NativeMapView.StateCallback {
       if (!onDidFailLoadingMapListenerList.isEmpty()) {
         for (MapView.OnDidFailLoadingMapListener onDidFailLoadingMapListener : onDidFailLoadingMapListenerList) {
           onDidFailLoadingMapListener.onDidFailLoadingMap(error);
+        }
+      }
+    } catch (Throwable err) {
+      Logger.e(TAG, "Exception in onDidFailLoadingMap", err);
+      throw err;
+    }
+  }
+
+  @Override
+  public void onDidFailLoadingTile(String error) {
+    try {
+      if (!onDidFailLoadingTileListenerList.isEmpty()) {
+        for (MapView.OnDidFailLoadingTileListener onDidFailLoadingTileListener : onDidFailLoadingTileListenerList) {
+          onDidFailLoadingTileListener.onDidFailLoadingTile(error);
         }
       }
     } catch (Throwable err) {
@@ -303,6 +319,14 @@ class MapChangeReceiver implements NativeMapView.StateCallback {
     onDidFailLoadingMapListenerList.remove(listener);
   }
 
+  void addOnDidFailLoadingTileListener(MapView.OnDidFailLoadingTileListener listener) {
+    onDidFailLoadingTileListenerList.add(listener);
+  }
+
+  void removeOnDidFailLoadingTileListener(MapView.OnDidFailLoadingTileListener listener) {
+    onDidFailLoadingTileListenerList.remove(listener);
+  }
+
   void addOnWillStartRenderingFrameListener(MapView.OnWillStartRenderingFrameListener listener) {
     onWillStartRenderingFrameList.add(listener);
   }
@@ -382,6 +406,7 @@ class MapChangeReceiver implements NativeMapView.StateCallback {
     onWillStartLoadingMapListenerList.clear();
     onDidFinishLoadingMapListenerList.clear();
     onDidFailLoadingMapListenerList.clear();
+    onDidFailLoadingTileListenerList.clear();
     onWillStartRenderingFrameList.clear();
     onDidFinishRenderingFrameList.clear();
     onWillStartRenderingMapListenerList.clear();

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapChangeReceiver.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapChangeReceiver.java
@@ -131,7 +131,7 @@ class MapChangeReceiver implements NativeMapView.StateCallback {
         }
       }
     } catch (Throwable err) {
-      Logger.e(TAG, "Exception in onDidFailLoadingMap", err);
+      Logger.e(TAG, "Exception in onDidFailLoadingTile", err);
       throw err;
     }
   }

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -768,6 +768,24 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   }
 
   /**
+   * Set a callback that's invoked when the tile failed to load.
+   *
+   * @param listener The callback that's invoked when the tile failed to load
+   */
+  public void addOnDidFailLoadingTileListener(@NonNull OnDidFailLoadingTileListener listener) {
+    mapChangeReceiver.addOnDidFailLoadingTileListener(listener);
+  }
+
+  /**
+   * Set a callback that's invoked when the tile failed to load.
+   *
+   * @param listener The callback that's invoked when the tile failed to load
+   */
+  public void removeOnDidFailLoadingTileListener(@NonNull OnDidFailLoadingTileListener listener) {
+    mapChangeReceiver.removeOnDidFailLoadingTileListener(listener);
+  }
+
+  /**
    * Set a callback that's invoked when the map will start rendering a frame.
    *
    * @param listener The callback that's invoked when the camera will start rendering a frame
@@ -1023,6 +1041,21 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   }
 
   /**
+   * Interface definition for a callback to be invoked when the tile failed to load.
+   * <p>
+   * {@link MapView#addOnDidFailLoadingTileListener(OnDidFailLoadingTileListener)}
+   * </p>
+   */
+  public interface OnDidFailLoadingTileListener {
+    /**
+     * Called when the tile failed to load.
+     *
+     * @param errorMessage The reason why the tile failed to load
+     */
+    void onDidFailLoadingTile(String errorMessage);
+  }
+
+  /**
    * Interface definition for a callback to be invoked when the map will start rendering a frame.
    * <p>
    * {@link MapView#addOnWillStartRenderingFrameListener(OnWillStartRenderingFrameListener)}
@@ -1053,7 +1086,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   /**
    * Interface definition for a callback to be invoked when the map will start rendering the map.
    * <p>
-   * {@link MapView#addOnDidFailLoadingMapListener(OnDidFailLoadingMapListener)}
+   * {@link MapView#addOnWillStartRenderingMapListener(OnWillStartRenderingMapListener)}
    * </p>
    */
   public interface OnWillStartRenderingMapListener {
@@ -1098,7 +1131,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   /**
    * Interface definition for a callback to be invoked when the map has loaded the style.
    * <p>
-   * {@link MapView#addOnDidFailLoadingMapListener(OnDidFailLoadingMapListener)}
+   * {@link MapView#addOnDidFinishLoadingStyleListener(OnDidFinishLoadingStyleListener)}
    * </p>
    */
   public interface OnDidFinishLoadingStyleListener {
@@ -1111,7 +1144,7 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   /**
    * Interface definition for a callback to be invoked when a map source has changed.
    * <p>
-   * {@link MapView#addOnDidFailLoadingMapListener(OnDidFailLoadingMapListener)}
+   * {@link MapView#addOnSourceChangedListener(OnSourceChangedListener)}
    * </p>
    */
   public interface OnSourceChangedListener {

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -1126,6 +1126,13 @@ final class NativeMapView implements NativeMap {
   }
 
   @Keep
+  private void onDidFailLoadingTile(String error) {
+    if (stateCallback != null) {
+      stateCallback.onDidFailLoadingTile(error);
+    }
+  }
+
+  @Keep
   private void onWillStartRenderingFrame() {
     if (stateCallback != null) {
       stateCallback.onWillStartRenderingFrame();
@@ -1644,6 +1651,8 @@ final class NativeMapView implements NativeMap {
     void onDidFinishLoadingMap();
 
     void onDidFailLoadingMap(String error);
+
+    void onDidFailLoadingTile(String error);
 
     void onWillStartRenderingFrame();
 

--- a/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/MapChangeReceiverTest.java
+++ b/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/maps/MapChangeReceiverTest.java
@@ -44,6 +44,9 @@ public class MapChangeReceiverTest {
   private MapView.OnDidFailLoadingMapListener onDidFailLoadingMapListener;
 
   @Mock
+  private MapView.OnDidFailLoadingTileListener onDidFailLoadingTileListener;
+
+  @Mock
   private MapView.OnWillStartRenderingFrameListener onWillStartRenderingFrameListener;
 
   @Mock
@@ -308,6 +311,36 @@ public class MapChangeReceiverTest {
     doThrow(err).when(onDidFailLoadingMapListener).onDidFailLoadingMap(TEST_STRING);
     try {
       mapChangeEventManager.onDidFailLoadingMap(TEST_STRING);
+      Assert.fail("The exception should've been re-thrown.");
+    } catch (ExecutionError throwable) {
+      verify(loggerDefinition).e(anyString(), anyString(), eq(err));
+    }
+  }
+
+  @Test
+  public void testOnDidFailLoadingTileListener() {
+    mapChangeEventManager.addOnDidFailLoadingTileListener(onDidFailLoadingTileListener);
+    mapChangeEventManager.onDidFailLoadingTile(TEST_STRING);
+    verify(onDidFailLoadingTileListener).onDidFailLoadingTile(TEST_STRING);
+    mapChangeEventManager.removeOnDidFailLoadingTileListener(onDidFailLoadingTileListener);
+    mapChangeEventManager.onDidFailLoadingTile(TEST_STRING);
+    verify(onDidFailLoadingTileListener).onDidFailLoadingTile(TEST_STRING);
+
+    mapChangeEventManager.addOnDidFailLoadingTileListener(onDidFailLoadingTileListener);
+    Logger.setLoggerDefinition(loggerDefinition);
+    Exception exc = new RuntimeException();
+    doThrow(exc).when(onDidFailLoadingTileListener).onDidFailLoadingTile(TEST_STRING);
+    try {
+      mapChangeEventManager.onDidFailLoadingTile(TEST_STRING);
+      Assert.fail("The exception should've been re-thrown.");
+    } catch (RuntimeException throwable) {
+      verify(loggerDefinition).e(anyString(), anyString(), eq(exc));
+    }
+
+    Error err = new ExecutionError("", new Error());
+    doThrow(err).when(onDidFailLoadingTileListener).onDidFailLoadingTile(TEST_STRING);
+    try {
+      mapChangeEventManager.onDidFailLoadingTile(TEST_STRING);
       Assert.fail("The exception should've been re-thrown.");
     } catch (ExecutionError throwable) {
       verify(loggerDefinition).e(anyString(), anyString(), eq(err));

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -40,7 +40,7 @@ ext {
             ktlint           : '0.34.0',
             commonsIO        : '2.6',
             mapboxSdkVersions: '1.1.0',
-            mapboxSdkCore    : '5.2.2',
+            mapboxSdkCore    : '5.3.0',
             mapboxSdkRegistryPlugin: '0.3.0',
             okio             : '2.4.3'
     ]


### PR DESCRIPTION
This PR adds the OnDidFailLoadingTileListener to monitor tile loading errors.

`<changelog>Handle exceptions thrown at layout initialization (including those thrown from vector tile parsing) and add OnDidFailLoadingTileListener, which will be trigged when tile failed to load.</changelog>`

<!-- Examples: -->
<!-- `<changelog>Enabled reusing objects with `Projection.getVisibleCoordinateBounds`.</changelog>` -->
<!-- `<changelog>Added an option to set the minimum and maximum pitch of a `Map`.</changelog>`-->
<!-- `<changelog>Introduced `in` expression for testing whether an item exists in an array or a substring exists in a string.</changelog>`
<!-- `<changelog>Significantly improved offline pack download performance by marking resources as used in batches.</changelog>`
<!-- `<changelog>Fixed a bug where non-overlapping symbols would be sorted incorrectly with `SymbolLayer.symbolSortKey`.</changelog>` -->


