### PR TITLE
Include "tk." as a valid prefix for access token

### DIFF
--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
@@ -216,7 +216,7 @@ public final class Mapbox {
     }
 
     accessToken = accessToken.trim().toLowerCase(MapboxConstants.MAPBOX_LOCALE);
-    return accessToken.length() != 0 && (accessToken.startsWith("pk.") || accessToken.startsWith("sk."));
+    return accessToken.length() > 0 && accessToken.matches("^(pk|sk|tk)\\..*");
   }
 
   /**

--- a/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/MapboxTest.java
+++ b/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/MapboxTest.java
@@ -68,6 +68,11 @@ public class MapboxTest {
   }
 
   @Test
+  public void testTkTokenValid() {
+    assertTrue(Mapbox.isAccessTokenValid("tk.0000000001"));
+  }
+
+  @Test
   public void testEmptyToken() {
     assertFalse(Mapbox.isAccessTokenValid(""));
   }


### PR DESCRIPTION
Temporary tokens created via the [token creation API][1] are prefixed
with `tk.` and are still valid access tokens.

This issue is related to and fixes https://github.com/react-native-mapbox-gl/maps/issues/1541

[1]: https://docs.mapbox.com/api/accounts/tokens/#create-a-temporary-token

`<changelog>Included "tk." as a valid prefix for access token</changelog>`
