### PR TITLE
fix high contrast bug

### DIFF
--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -36,6 +36,7 @@ import com.mapbox.mapboxsdk.maps.renderer.textureview.TextureViewMapRenderer;
 import com.mapbox.mapboxsdk.maps.widgets.CompassView;
 import com.mapbox.mapboxsdk.net.ConnectivityReceiver;
 import com.mapbox.mapboxsdk.storage.FileSource;
+import com.mapbox.mapboxsdk.utils.AccessibilityUtils;
 import com.mapbox.mapboxsdk.utils.BitmapUtils;
 
 import java.util.ArrayList;
@@ -313,7 +314,10 @@ public class MapView extends FrameLayout implements NativeMapView.ViewCallback {
   }
 
   private void initialiseDrawingSurface(MapboxMapOptions options) {
-    String localFontFamily = options.getLocalIdeographFontFamily();
+    String localFontFamily = null;
+    if (!AccessibilityUtils.isHighContrastEnabled(getContext())) {
+      localFontFamily = options.getLocalIdeographFontFamily();
+    }
     GlyphsRasterizationMode glyphsRasterizationMode = options.getGlyphsRasterizationMode();
     if (options.getTextureMode()) {
       TextureView textureView = new TextureView(getContext());

--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/AccessibilityUtils.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/AccessibilityUtils.java
@@ -1,0 +1,29 @@
+package com.mapbox.mapboxsdk.utils;
+
+import android.content.Context;
+import android.view.accessibility.AccessibilityManager;
+import androidx.annotation.NonNull;
+import com.mapbox.mapboxsdk.log.Logger;
+import java.lang.reflect.Method;
+
+public class AccessibilityUtils {
+  private static final String TAG = "Mbgl-AccessibilityUtils";
+  private static final String METHOD_HIGH_TEXT_CONTRAST_ENABLED = "isHighTextContrastEnabled";
+  private static final String ERROR_HIGH_CONTRAST_LOOKUP =
+            "Could not detect high text contrast accessibility setting";
+
+  @SuppressWarnings("JavaReflectionMemberAccess")
+  public static boolean isHighContrastEnabled(@NonNull Context context) {
+    AccessibilityManager accessibility = (AccessibilityManager) context.getSystemService(Context.ACCESSIBILITY_SERVICE);
+    try {
+      Method m = accessibility.getClass().getMethod(METHOD_HIGH_TEXT_CONTRAST_ENABLED);
+      Object result = m.invoke(accessibility);
+      if (result instanceof Boolean) {
+        return (Boolean) result;
+      }
+    } catch (Exception exception) {
+      Logger.i(TAG, ERROR_HIGH_CONTRAST_LOOKUP, exception);
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
This PR fix the high contrast text rendering when accessibility is enabled. Fixes : https://github.com/mapbox/mapbox-gl-native-android/issues/711

`<changelog>Fix high contrast text rendering when accessibility enabled.</changelog>`

Before -
![before](https://user-images.githubusercontent.com/11589497/136521131-6a6ce405-4443-4193-9000-db7fd97a5892.jpg)


After - 
![after](https://user-images.githubusercontent.com/11589497/136521146-7c51220e-9ee2-44b5-be15-5a65c39e6e55.jpg)


