### PR TITLE
[ci skip] v10 is now in GA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [Mapbox Maps SDK for Android](https://www.mapbox.com/android-sdk/)
 
-Mapbox Maps SDK v10 beta is now available at [mapbox/mapbox-maps-android](https://github.com/mapbox/mapbox-maps-android). Mapbox maintains this repo to address bug fixes and security vulnerabilities.
+Mapbox Maps SDK v10 is now available at [mapbox/mapbox-maps-android](https://github.com/mapbox/mapbox-maps-android). v10 offers superior performance, features, and developer experience, and is the recommended mobile SDK solution for all Mapbox customers. Mapbox maintains this repo to address bug fixes and security vulnerabilities.
 
 [![Circle CI build status](https://circleci.com/gh/mapbox/mapbox-gl-native-android/tree/master.svg?style=shield)](https://circleci.com/gh/mapbox/mapbox-gl-native-android/tree/master)
 


### PR DESCRIPTION
update README to avoid giving false impression that v10 is still in beta