### PR TITLE
[egl] add additional check against eglcontext

### DIFF
--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/glsurfaceview/MapboxGLSurfaceView.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/renderer/glsurfaceview/MapboxGLSurfaceView.java
@@ -432,6 +432,10 @@ public class MapboxGLSurfaceView extends SurfaceView implements SurfaceHolder.Ca
         Log.e(TAG, "mEglConfig not initialized");
         return false;
       }
+      if (mEglContext == null) {
+        Log.e(TAG, "mEglContext not initialized");
+        return false;
+      }
 
       /*
        *  The window size has changed, so we need to create a new


### PR DESCRIPTION
This PR adds an additional check against eglContext being null. This avoids having our GL context in an invalid state and as results run into an IllegalArgumentException on the OS level.