### PR TITLE
Include "tk." as a valid access token prefix

### DIFF
--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
@@ -216,7 +216,7 @@ public final class Mapbox {
     }
 
     accessToken = accessToken.trim().toLowerCase(MapboxConstants.MAPBOX_LOCALE);
-    return accessToken.length() != 0 && (accessToken.startsWith("pk.") || accessToken.startsWith("sk."));
+    return accessToken.length() > 0 && accessToken.matches("^(pk|sk|tk)\\..*");
   }
 
   /**

--- a/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/MapboxTest.java
+++ b/MapboxGLAndroidSDK/src/test/java/com/mapbox/mapboxsdk/MapboxTest.java
@@ -68,6 +68,11 @@ public class MapboxTest {
   }
 
   @Test
+  public void testTkTokenValid() {
+    assertTrue(Mapbox.isAccessTokenValid("tk.0000000001"));
+  }
+
+  @Test
   public void testEmptyToken() {
     assertFalse(Mapbox.isAccessTokenValid(""));
   }


### PR DESCRIPTION
Temporary tokens created via the [token creation API][1] are prefixed
with `tk.` and are still valid access tokens.

This issue is related to and fixes
https://github.com/react-native-mapbox-gl/maps/issues/1541

[1]: https://docs.mapbox.com/api/accounts/tokens/#create-a-temporary-token

`<changelog>Replace text with suggested changelog entry for this PR or add the 'skip changelog' label.</changelog>`

<!-- Examples: -->
<!-- `<changelog>Enabled reusing objects with `Projection.getVisibleCoordinateBounds`.</changelog>` -->
<!-- `<changelog>Added an option to set the minimum and maximum pitch of a `Map`.</changelog>`-->
<!-- `<changelog>Introduced `in` expression for testing whether an item exists in an array or a substring exists in a string.</changelog>`
<!-- `<changelog>Significantly improved offline pack download performance by marking resources as used in batches.</changelog>`
<!-- `<changelog>Fixed a bug where non-overlapping symbols would be sorted incorrectly with `SymbolLayer.symbolSortKey`.</changelog>` -->


