### PR TITLE
[Bugfix]  crash in Android 14  "latitude must not be NaN"

### DIFF
--- a/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LatLngEvaluator.java
+++ b/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LatLngEvaluator.java
@@ -12,6 +12,7 @@ class LatLngEvaluator implements TypeEvaluator<LatLng> {
   @NonNull
   @Override
   public LatLng evaluate(float fraction, @NonNull LatLng startValue, @NonNull LatLng endValue) {
+    fraction = Double.isNaN(fraction) ? 0f : fraction;
     latLng.setLatitude(startValue.getLatitude()
       + ((endValue.getLatitude() - startValue.getLatitude()) * fraction));
     latLng.setLongitude(startValue.getLongitude()


### PR DESCRIPTION


`<changelog>Bugfix when in Android 14 the fraction is a NaN the app will crash. when  the map comes from background to foreground</changelog>`



